### PR TITLE
fix(auth): distinguish unauthenticated vs unauthorized in PrivateRoute

### DIFF
--- a/src/components/PrivateRoute/PrivateRoute.jsx
+++ b/src/components/PrivateRoute/PrivateRoute.jsx
@@ -2,14 +2,18 @@ import { Navigate, useLocation } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 
 const PrivateRoute = ({ children }) => {
-  const user = useSelector((state) => state.user);
+  const { isAuth, role } = useSelector((state) => state.user);
   const location = useLocation();
 
-  if (user.isAuth && user.role === 'admin') {
-    return children;
+  if (!isAuth) {
+    return <Navigate to={`/login?redirect=${location.pathname}`} replace />;
   }
 
-  return <Navigate to={`/login?redirect=${location.pathname}`} />;
+  if (role !== 'admin') {
+    return <Navigate to="/courses" replace />;
+  }
+
+  return children;
 };
 
 export default PrivateRoute;


### PR DESCRIPTION
Previously both cases redirected to /login, which is semantically wrong for authenticated users lacking admin role (403 vs 401).

- Unauthenticated users are redirected to /login with redirect param
- Authenticated non-admin users are redirected to /courses
- Added  to both redirects to prevent broken browser history