### PR TITLE
refactor(store): replace module-level localStorage reads with lazy in…

### DIFF
--- a/src/store/user/reducer.js
+++ b/src/store/user/reducer.js
@@ -1,21 +1,18 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { fetchUser, loginUser, logoutUser } from './thunk';
 
-const userName = localStorage.getItem('userName');
-const userEmail = localStorage.getItem('userEmail');
-const userIsAuth = localStorage.getItem('isAuth') === 'true';
-const userRole = localStorage.getItem('userRole');
+const loadUserFromStorage = () => ({
+  name: localStorage.getItem('userName') || null,
+  email: localStorage.getItem('userEmail') || null,
+  isAuth: localStorage.getItem('isAuth') === 'true',
+  role: localStorage.getItem('userRole') || null,
+  status: 'idle',
+  error: null,
+});
 
 const userSlice = createSlice({
   name: 'user',
-  initialState: {
-    name: userName || null,
-    email: userEmail || null,
-    isAuth: userIsAuth || false,
-    role: userRole || null,
-    status: 'idle',
-    error: null,
-  },
+  initialState: loadUserFromStorage,
   reducers: {
     setUser: (state, action) => {
       state.name = action.payload.name;


### PR DESCRIPTION
…itializer

Reading localStorage at module import time causes side effects on every import, making tests harder to isolate and breaking SSR environments where localStorage is undefined.

Extracted reads into loadUserFromStorage function passed as a lazy initializer to createSlice. RTK calls it only when the store is created, and preloadedState in tests bypasses it entirely.