### PR TITLE
refactor(common): remove deprecated defaultProps from Input component

### DIFF
--- a/src/common/Input/Input.jsx
+++ b/src/common/Input/Input.jsx
@@ -1,13 +1,16 @@
 import React from 'react';
-import { HAS_ERROR_CLASS, ERROR_TEXT_CLASS } from '../../constants';
 import PropTypes from 'prop-types';
+import { HAS_ERROR_CLASS, ERROR_TEXT_CLASS } from '../../constants';
 
-function Input({ name, value, onChange, error, placeholder, type = 'text' }) {
-  let inputClasses = 'input-class';
-
-  if (error) {
-    inputClasses += ` ${HAS_ERROR_CLASS}`;
-  }
+function Input({
+  name,
+  value,
+  onChange,
+  error = null,
+  placeholder = '',
+  type = 'text',
+}) {
+  const inputClassName = `input-class${error ? ` ${HAS_ERROR_CLASS}` : ''}`;
 
   return (
     <div className="input-wrapper">
@@ -17,7 +20,7 @@ function Input({ name, value, onChange, error, placeholder, type = 'text' }) {
         value={value}
         onChange={onChange}
         placeholder={placeholder}
-        className={inputClasses}
+        className={inputClassName}
       />
       {error && <small className={ERROR_TEXT_CLASS}>{error}</small>}
     </div>
@@ -31,12 +34,6 @@ Input.propTypes = {
   error: PropTypes.string,
   placeholder: PropTypes.string,
   type: PropTypes.string,
-};
-
-Input.defaultProps = {
-  type: 'text',
-  error: null,
-  placeholder: '',
 };
 
 export default Input;


### PR DESCRIPTION
React 18 deprecated defaultProps for function components and React 19 will remove them entirely. Having both default parameters and defaultProps in the same component was also redundant and contradictory.

- Moved all default values to destructuring parameters
- Removed Input.defaultProps entirely
- Replaced mutable let + string concatenation with a const expression for conditional className construction