### PR TITLE
refactor(courses): remove redundant fetchUser dispatch and auth guard

### DIFF
--- a/src/components/Courses/Courses.jsx
+++ b/src/components/Courses/Courses.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import CourseCard from './components/CourseCard/CourseCard';
@@ -6,7 +6,6 @@ import SearchBar from './components/SearchBar/SearchBar';
 import Button from '../../common/Button/Button';
 import EmptyCourseList from './components/EmptyCourseList';
 import { ADD_NEW_COURSE_LABEL } from '../../constants';
-import { fetchUser } from '../../store/user/thunk';
 import './Courses.css';
 
 function Courses() {
@@ -22,22 +21,15 @@ function Courses() {
 
   const [query, setQuery] = useState('');
 
-  useEffect(() => {
-    dispatch(fetchUser());
-    if (!user.isAuth) {
-      navigate('/login');
-    }
-  }, [dispatch, user.isAuth, navigate]);
-
-  const handleSearch = (inputQuery) => {
-    setQuery(inputQuery);
-  };
-
   const filteredCourses = useMemo(() => {
     return courses.filter((course) =>
       course.title.toLowerCase().includes(query.toLowerCase())
     );
   }, [courses, query]);
+
+  const handleSearch = (inputQuery) => {
+    setQuery(inputQuery);
+  };
 
   const handleAddNewCourse = () => {
     navigate('/courses/add');


### PR DESCRIPTION
Courses component was dispatching fetchUser on every mount despite App.jsx already doing it once at application startup, causing a duplicate HTTP request on every visit to the courses page.

The isAuth guard was also unreachable — App.jsx already redirects unauthenticated users to /login before Courses can render.

- Removed useEffect with fetchUser dispatch and navigation guard
- Removed unused useEffect and fetchUser imports