### PR TITLE
refactor(search-bar): replace submit-based search with live search

### DIFF
--- a/src/components/Courses/components/SearchBar/SearchBar.jsx
+++ b/src/components/Courses/components/SearchBar/SearchBar.jsx
@@ -1,29 +1,28 @@
 import React, { useState } from 'react';
-import { INPUT_PLACEHOLDER, SEARCH_BUTTON_LABEL } from '../../../../constants';
-import Button from '../../../../common/Button/Button';
+import { INPUT_PLACEHOLDER } from '../../../../constants';
 import './SearchBar.css';
 
 const SearchBar = ({ onSearch }) => {
   const [query, setQuery] = useState('');
 
   const handleChange = (event) => {
-    setQuery(event.target.value);
+    const { value } = event.target;
+    setQuery(value);
+    onSearch(value);
   };
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    onSearch(query);
   };
 
   return (
     <form className="Search-bar" onSubmit={handleSubmit}>
       <input
-        type="text"
+        type="search"
         value={query}
         onChange={handleChange}
         placeholder={INPUT_PLACEHOLDER}
       />
-      <Button label={SEARCH_BUTTON_LABEL} className="ButtonBar" type="submit" />
     </form>
   );
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,7 +4,6 @@ export const MIN_COURSE_DESCRIPTION_LENGTH = 2;
 export const MAX_AUTHORS_DISPLAY_LENGTH = 30;
 
 export const INPUT_PLACEHOLDER = 'Input text';
-export const SEARCH_BUTTON_LABEL = 'SEARCH';
 export const ADD_NEW_COURSE_LABEL = 'ADD NEW COURSE';
 export const BACK_TO_COURSES_LABEL = 'BACK TO COURSES';
 export const LOGIN_LABEL = 'LOGIN';


### PR DESCRIPTION
SearchBar was requiring a button click to trigger filtering, while Courses was already set up to filter reactively on every query change via useMemo. This mismatch meant the UI blocked what the logic was ready to do immediately.

Since course data is already in Redux store (no HTTP request on search), live search is the correct pattern here.

- onSearch now called on every input change instead of on form submit
- Removed SEARCH button — unnecessary for live search
- Changed input type from text to search for native clear button
- Removed unused SEARCH_BUTTON_LABEL constant from constants.js
- Kept form element for semantic HTML and native Enter key handling