### PR TITLE
fix(course-info): handle loading state before checking course existence

### DIFF
--- a/src/components/CourseInfo/CourseInfo.jsx
+++ b/src/components/CourseInfo/CourseInfo.jsx
@@ -5,15 +5,39 @@ import formatCreationDate from '../../helpers/formatCreationDate';
 import getCourseDuration from '../../helpers/getCourseDuration';
 import './CourseInfo.css';
 
+const COURSE_INFO_LOADING_MESSAGE = 'Loading course...';
+const COURSE_INFO_NOT_FOUND_MESSAGE = 'Course not found.';
+
 function CourseInfo() {
   const { courseId } = useParams();
+
+  const coursesStatus = useSelector((state) => state.courses.status);
+  const authorsStatus = useSelector((state) => state.authors.status);
   const courses = useSelector((state) => state.courses.courses);
   const authors = useSelector((state) => state.authors.authors);
+
+  const isLoading =
+    coursesStatus === 'loading' || authorsStatus === 'loading';
+
+  if (isLoading) {
+    return (
+      <div className="Course-all">
+        <p>{COURSE_INFO_LOADING_MESSAGE}</p>
+      </div>
+    );
+  }
 
   const course = courses.find((c) => c.id === courseId);
 
   if (!course) {
-    return <p>Course not found</p>;
+    return (
+      <div className="Course-all">
+        <p>{COURSE_INFO_NOT_FOUND_MESSAGE}</p>
+        <Link to="/courses" className="back-button">
+          Back to Courses
+        </Link>
+      </div>
+    );
   }
 
   const authorNames = course.authors
@@ -46,7 +70,7 @@ function CourseInfo() {
             </p>
             <p>
               <strong>Authors: </strong>
-              {authorNames}
+              {authorNames || 'No authors assigned'}
             </p>
             <p>
               <strong>Creation Date: </strong>


### PR DESCRIPTION
CourseInfo was returning 'Course not found' during data fetch because courses array is empty while status is loading. This caused a false error message on direct URL navigation or page refresh.

- Added coursesStatus and authorsStatus selectors
- Early return with loading message when either slice is fetching
- course.find() is now only called after data is confirmed loaded
- Not found state now includes a back link to prevent dead end
- Added fallback for courses with no authors assigned
- Extracted string constants for future i18n compatibility