### PR TITLE
refactor(constants): split monolithic constants.js into domain files

### DIFF
--- a/src/common/Input/Input.jsx
+++ b/src/common/Input/Input.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { HAS_ERROR_CLASS, ERROR_TEXT_CLASS } from '../../constants';
+import { HAS_ERROR_CLASS, ERROR_TEXT_CLASS } from '../../constants/ui';
 
 function Input({
   name,

--- a/src/components/Courses/Courses.jsx
+++ b/src/components/Courses/Courses.jsx
@@ -5,7 +5,7 @@ import CourseCard from './components/CourseCard/CourseCard';
 import SearchBar from './components/SearchBar/SearchBar';
 import Button from '../../common/Button/Button';
 import EmptyCourseList from './components/EmptyCourseList';
-import { ADD_NEW_COURSE_LABEL } from '../../constants';
+import { ADD_NEW_COURSE_LABEL } from '../../constants/ui';
 import './Courses.css';
 
 function Courses() {

--- a/src/components/Courses/components/CourseCard/CourseCard.jsx
+++ b/src/components/Courses/components/CourseCard/CourseCard.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import Button from '../../../../common/Button/Button';
 import { useDispatch, useSelector } from 'react-redux';
-import { deleteCourse } from '../../../../store/courses/thunk';
 import { useNavigate } from 'react-router-dom';
+import Button from '../../../../common/Button/Button';
+import { deleteCourse } from '../../../../store/courses/thunk';
 import formatCreationDate from '../../../../helpers/formatCreationDate';
 import getCourseDuration from '../../../../helpers/getCourseDuration';
-import { MAX_AUTHORS_DISPLAY_LENGTH } from '../../../../constants';
+import { MAX_AUTHORS_DISPLAY_LENGTH } from '../../../../constants/validation';
 import './CourseCard.css';
 
 const getAuthorsString = (courseAuthors, authors) => {
@@ -20,7 +20,7 @@ const getAuthorsString = (courseAuthors, authors) => {
     .join(', ');
 
   return names.length > MAX_AUTHORS_DISPLAY_LENGTH
-    ? names.substring(0, MAX_AUTHORS_DISPLAY_LENGTH - 3) + '...'
+    ? `${names.substring(0, MAX_AUTHORS_DISPLAY_LENGTH - 3)}...`
     : names;
 };
 

--- a/src/components/Courses/components/SearchBar/SearchBar.jsx
+++ b/src/components/Courses/components/SearchBar/SearchBar.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { INPUT_PLACEHOLDER } from '../../../../constants';
+import { INPUT_PLACEHOLDER } from '../../../../constants/ui';
 import './SearchBar.css';
 
 const SearchBar = ({ onSearch }) => {

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { LOGIN_LABEL } from '../../constants';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { logoutUser } from '../../store/user/thunk';
+import { LOGIN_LABEL } from '../../constants/ui';
 import Logo from './components/Logo/Logo';
 import Button from '../../common/Button/Button';
-
 import './Header.css';
 
 function Header() {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,2 @@
+export * from './validation';
+export * from './ui';

--- a/src/constants/ui.js
+++ b/src/constants/ui.js
@@ -1,8 +1,3 @@
-export const MIN_PASSWORD_LENGTH = 6;
-export const MIN_COURSE_TITLE_LENGTH = 2;
-export const MIN_COURSE_DESCRIPTION_LENGTH = 2;
-export const MAX_AUTHORS_DISPLAY_LENGTH = 30;
-
 export const INPUT_PLACEHOLDER = 'Input text';
 export const ADD_NEW_COURSE_LABEL = 'ADD NEW COURSE';
 export const BACK_TO_COURSES_LABEL = 'BACK TO COURSES';

--- a/src/constants/validation.js
+++ b/src/constants/validation.js
@@ -1,0 +1,4 @@
+export const MIN_PASSWORD_LENGTH = 6;
+export const MIN_COURSE_TITLE_LENGTH = 2;
+export const MIN_COURSE_DESCRIPTION_LENGTH = 2;
+export const MAX_AUTHORS_DISPLAY_LENGTH = 30;


### PR DESCRIPTION
A single constants.js mixing validation rules, UI labels and CSS class names violates SRP at the module level and grows unboundedly with the app.

- Created src/constants/validation.js for business logic limits
- Created src/constants/ui.js for labels, placeholders and CSS classes
- Created src/constants/index.js re-exporting both for backward compatibility — existing imports from 'constants' continue to work
- Updated all consumers to import from the precise domain subfile
- Removed src/constants.js