### PR TITLE
test: mock services in component tests and add thunk unit tests

### DIFF
--- a/src/components/Courses/components/CourseCard/tests/courseCard.test.js
+++ b/src/components/Courses/components/CourseCard/tests/courseCard.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { MemoryRouter as Router } from 'react-router-dom';
 import { configureStore } from '@reduxjs/toolkit';
@@ -7,6 +7,9 @@ import userReducer from '../../../../../store/user/reducer';
 import coursesReducer from '../../../../../store/courses/reducer';
 import authorsReducer from '../../../../../store/authors/reducer';
 import CourseCard from '../CourseCard';
+import { deleteCourseService } from '../../../../../services';
+
+jest.mock('../../../../../services');
 
 const initialState = {
   user: {
@@ -64,6 +67,13 @@ const renderCourseCard = (state = initialState) =>
   );
 
 describe('CourseCard Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    deleteCourseService.mockResolvedValue({
+      data: { successful: true },
+    });
+  });
+
   it('should display course title', () => {
     renderCourseCard();
     expect(screen.getByText('Sample Course')).toBeInTheDocument();
@@ -107,5 +117,15 @@ describe('CourseCard Component', () => {
 
     expect(screen.queryByText('DELETE')).not.toBeInTheDocument();
     expect(screen.queryByText('UPDATE')).not.toBeInTheDocument();
+  });
+
+  it('should call deleteCourseService when DELETE button is clicked', async () => {
+    renderCourseCard();
+
+    fireEvent.click(screen.getByText('DELETE'));
+
+    await waitFor(() => {
+      expect(deleteCourseService).toHaveBeenCalledWith(sampleCourse.id);
+    });
   });
 });

--- a/src/components/Courses/tests/courses.test.js
+++ b/src/components/Courses/tests/courses.test.js
@@ -7,6 +7,13 @@ import userReducer from '../../../store/user/reducer';
 import coursesReducer from '../../../store/courses/reducer';
 import authorsReducer from '../../../store/authors/reducer';
 import Courses from '../Courses';
+import {
+  getCoursesService,
+  getAuthorsService,
+  getUserService,
+} from '../../../services';
+
+jest.mock('../../../services');
 
 const initialState = {
   user: {
@@ -72,6 +79,15 @@ const renderCourses = (state = initialState) =>
 describe('Courses Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    getCoursesService.mockResolvedValue({
+      data: { successful: true, result: [] },
+    });
+    getAuthorsService.mockResolvedValue({
+      data: { successful: true, result: [] },
+    });
+    getUserService.mockResolvedValue({
+      data: { successful: true, result: { name: 'Test Name', role: 'admin' } },
+    });
   });
 
   it('should display a CourseCard for each course in the store', () => {

--- a/src/components/Header/tests/header.test.js
+++ b/src/components/Header/tests/header.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter as Router } from 'react-router-dom';
@@ -7,6 +7,9 @@ import userReducer from '../../../store/user/reducer';
 import coursesReducer from '../../../store/courses/reducer';
 import authorsReducer from '../../../store/authors/reducer';
 import Header from '../Header';
+import { logoutUserService } from '../../../services';
+
+jest.mock('../../../services');
 
 const initialState = {
   user: {
@@ -38,6 +41,13 @@ const buildStore = (state = initialState) =>
     preloadedState: state,
   });
 
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
 const renderHeader = (state = initialState) =>
   render(
     <Provider store={buildStore(state)}>
@@ -48,6 +58,11 @@ const renderHeader = (state = initialState) =>
   );
 
 describe('Header Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    logoutUserService.mockResolvedValue({ data: { successful: true } });
+  });
+
   it('should contain a logo', () => {
     renderHeader();
     expect(screen.getByAltText(/logo/i)).toBeInTheDocument();
@@ -72,5 +87,16 @@ describe('Header Component', () => {
     renderHeader(guestState);
 
     expect(screen.getByText('LOGIN')).toBeInTheDocument();
+  });
+
+  it('should call logoutUserService and navigate to /login on logout', async () => {
+    renderHeader();
+
+    fireEvent.click(screen.getByText('Logout'));
+
+    await waitFor(() => {
+      expect(logoutUserService).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+    });
   });
 });

--- a/src/store/courses/tests/think.test.js
+++ b/src/store/courses/tests/think.test.js
@@ -1,0 +1,133 @@
+import { configureStore } from '@reduxjs/toolkit';
+import coursesReducer from '../reducer';
+import { fetchCourses, createCourse, deleteCourse, updateCourse } from '../thunk';
+import {
+  getCoursesService,
+  createCourseService,
+  deleteCourseService,
+  updateCourseService,
+} from '../../../services';
+
+jest.mock('../../../services');
+
+const buildStore = (preloadedState) =>
+  configureStore({
+    reducer: { courses: coursesReducer },
+    preloadedState,
+  });
+
+describe('Courses Thunks', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('fetchCourses', () => {
+    it('should dispatch fulfilled and populate courses on success', async () => {
+      const mockCourses = [{ id: '1', title: 'Course 1' }];
+      getCoursesService.mockResolvedValueOnce({
+        data: { successful: true, result: mockCourses },
+      });
+
+      const store = buildStore();
+      await store.dispatch(fetchCourses());
+
+      const state = store.getState().courses;
+      expect(state.status).toBe('succeeded');
+      expect(state.courses).toEqual(mockCourses);
+      expect(state.error).toBeNull();
+    });
+
+    it('should dispatch rejected and set error on service failure', async () => {
+      getCoursesService.mockRejectedValueOnce(new Error('Network error'));
+
+      const store = buildStore();
+      await store.dispatch(fetchCourses());
+
+      const state = store.getState().courses;
+      expect(state.status).toBe('failed');
+      expect(state.error).toBe('Network error');
+    });
+
+    it('should dispatch rejected when successful flag is false', async () => {
+      getCoursesService.mockResolvedValueOnce({
+        data: { successful: false },
+      });
+
+      const store = buildStore();
+      await store.dispatch(fetchCourses());
+
+      const state = store.getState().courses;
+      expect(state.status).toBe('failed');
+    });
+  });
+
+  describe('createCourse', () => {
+    it('should add course to state on success', async () => {
+      const newCourse = { id: '2', title: 'New Course' };
+      createCourseService.mockResolvedValueOnce({
+        data: { successful: true, result: newCourse },
+      });
+
+      const store = buildStore();
+      await store.dispatch(createCourse({ title: 'New Course' }));
+
+      const state = store.getState().courses;
+      expect(state.courses).toContainEqual(newCourse);
+    });
+
+    it('should set error on failure', async () => {
+      createCourseService.mockRejectedValueOnce(new Error('Create failed'));
+
+      const store = buildStore();
+      await store.dispatch(createCourse({ title: 'New Course' }));
+
+      const state = store.getState().courses;
+      expect(state.error).toBe('Create failed');
+    });
+  });
+
+  describe('deleteCourse', () => {
+    it('should remove course from state on success', async () => {
+      deleteCourseService.mockResolvedValueOnce({
+        data: { successful: true },
+      });
+
+      const preloadedState = {
+        courses: {
+          courses: [{ id: '1', title: 'To Delete' }],
+          status: 'succeeded',
+          error: null,
+        },
+      };
+
+      const store = buildStore(preloadedState);
+      await store.dispatch(deleteCourse('1'));
+
+      const state = store.getState().courses;
+      expect(state.courses).toHaveLength(0);
+    });
+  });
+
+  describe('updateCourse', () => {
+    it('should update course in state on success', async () => {
+      const updatedCourse = { id: '1', title: 'Updated Title' };
+      updateCourseService.mockResolvedValueOnce({
+        data: { successful: true, result: updatedCourse },
+      });
+
+      const preloadedState = {
+        courses: {
+          courses: [{ id: '1', title: 'Old Title' }],
+          status: 'succeeded',
+          error: null,
+        },
+      };
+
+      const store = buildStore(preloadedState);
+      await store.dispatch(updateCourse(updatedCourse));
+
+      const state = store.getState().courses;
+      expect(state.courses[0].title).toBe('Updated Title');
+    });
+  });
+});


### PR DESCRIPTION
Component tests were relying on real service functions which could trigger HTTP requests in CI, making tests slow, non-deterministic and environment-dependent.

- Added jest.mock('../../../services') to all component test files
- Each service mock is set up in beforeEach with a default resolved value so tests start from a known, predictable state
- Added src/store/courses/tests/thunk.test.js covering all four course thunks: fetchCourses, createCourse, deleteCourse, updateCourse including success, network failure and application-level failure cases
- Added interaction tests: DELETE button calls deleteCourseService, Logout button calls logoutUserService and navigates to /login