### PR TITLE
fix(security): replace localStorage token with httpOnly cookie

### DIFF
--- a/backend-mock/package.json
+++ b/backend-mock/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "cookie-parser": "^1.4.6",
     "json-server": "^0.17.4"
   },
   "devDependencies": {

--- a/backend-mock/server.js
+++ b/backend-mock/server.js
@@ -1,27 +1,35 @@
 const jsonServer = require('json-server');
+const cookieParser = require('cookie-parser');
 
 const server = jsonServer.create();
-
 const router = jsonServer.router('db.json');
-
 const middlewares = jsonServer.defaults();
 
-// KONFIGURACJA SERWERA
+// SERVER CONFIGURATION
 
 server.use(middlewares);
-
 server.use(jsonServer.bodyParser);
+server.use(cookieParser());
+
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  sameSite: 'lax',
+  maxAge: 24 * 60 * 60 * 1000, // 24 godziny
+  // secure: true — when HTTPS
+};
+
+const AUTH_COOKIE_NAME = 'authToken';
 
 // CUSTOM ENDPOINTS (Mock Authentication)
 
 server.post('/login', (req, res) => {
   const { email, password } = req.body;
-
   const db = router.db;
-
   const user = db.get('users').find({ email, password }).value();
 
   if (user) {
+    res.cookie(AUTH_COOKIE_NAME, user.token, COOKIE_OPTIONS);
+
     res.json({
       successful: true,
       result: user.token,
@@ -41,7 +49,6 @@ server.post('/login', (req, res) => {
 
 server.post('/register', (req, res) => {
   const { name, email, password } = req.body;
-
   const db = router.db;
 
   const newUser = {
@@ -67,7 +74,8 @@ server.post('/register', (req, res) => {
 
 server.get('/users/me', (req, res) => {
   const db = router.db;
-  const token = req.headers.authorization || req.get('Authorization');
+
+  const token = req.cookies[AUTH_COOKIE_NAME];
 
   if (!token) {
     res.status(401).json({ successful: false, errors: ['No token provided'] });
@@ -91,6 +99,7 @@ server.get('/users/me', (req, res) => {
 });
 
 server.delete('/logout', (req, res) => {
+  res.clearCookie(AUTH_COOKIE_NAME);
   res.json({ successful: true });
 });
 
@@ -98,7 +107,6 @@ server.delete('/logout', (req, res) => {
 
 server.get('/courses/all', (req, res) => {
   const courses = router.db.get('courses').value();
-
   res.json({
     successful: true,
     result: courses,
@@ -122,7 +130,6 @@ server.post('/courses/add', (req, res) => {
 
 server.delete('/courses/:id', (req, res) => {
   router.db.get('courses').remove({ id: req.params.id }).write();
-
   res.json({ successful: true });
 });
 
@@ -162,8 +169,6 @@ server.post('/authors/add', (req, res) => {
     result: newAuthor,
   });
 });
-
-// LOGI URUCHOMIENIA SERWERA
 
 server.use(router);
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import './App.css';
 function App() {
   const dispatch = useDispatch();
   const user = useSelector((state) => state.user);
+  const isBootstrapping = user.status === 'bootstrapping';
   const defaultPath = user.isAuth ? '/courses' : '/login';
 
   useEffect(() => {
@@ -24,6 +25,17 @@ function App() {
     dispatch(fetchCourses());
     dispatch(fetchAuthors());
   }, [dispatch]);
+
+  if (isBootstrapping) {
+    return (
+      <div className="App">
+        <Header />
+        <div className="Content">
+          <p className="loading-message">Loading...</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="App">

--- a/src/services.js
+++ b/src/services.js
@@ -3,22 +3,12 @@ import { API_BASE_URL } from './config';
 
 const apiClient = axios.create({
   baseURL: API_BASE_URL,
-});
-
-apiClient.interceptors.request.use((config) => {
-  const token = localStorage.getItem('userToken');
-  if (token) {
-    config.headers.Authorization = token;
-  }
-  return config;
+  withCredentials: true,
 });
 
 apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
-    if (error.response?.status === 401) {
-      localStorage.removeItem('userToken');
-    }
     return Promise.reject(error);
   }
 );

--- a/src/store/user/reducer.js
+++ b/src/store/user/reducer.js
@@ -1,18 +1,18 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { fetchUser, loginUser, logoutUser } from './thunk';
 
-const loadUserFromStorage = () => ({
-  name: localStorage.getItem('userName') || null,
-  email: localStorage.getItem('userEmail') || null,
-  isAuth: localStorage.getItem('isAuth') === 'true',
-  role: localStorage.getItem('userRole') || null,
-  status: 'idle',
+const initialState = {
+  name: null,
+  email: null,
+  isAuth: false,
+  role: null,
+  status: 'bootstrapping',
   error: null,
-});
+};
 
 const userSlice = createSlice({
   name: 'user',
-  initialState: loadUserFromStorage,
+  initialState,
   reducers: {
     setUser: (state, action) => {
       state.name = action.payload.name;
@@ -27,17 +27,22 @@ const userSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(fetchUser.pending, (state) => {
-        state.status = 'loading';
+        state.status = 'bootstrapping';
       })
       .addCase(fetchUser.fulfilled, (state, action) => {
         state.status = 'succeeded';
         state.name = action.payload.name;
         state.email = action.payload.email;
         state.role = action.payload.role;
+        state.isAuth = true;
       })
-      .addCase(fetchUser.rejected, (state, action) => {
-        state.status = 'failed';
-        state.error = action.payload;
+      .addCase(fetchUser.rejected, (state) => {
+        state.status = 'idle';
+        state.isAuth = false;
+        state.name = null;
+        state.email = null;
+        state.role = null;
+        state.error = null;
       })
       .addCase(loginUser.pending, (state) => {
         state.status = 'loading';
@@ -62,6 +67,13 @@ const userSlice = createSlice({
         state.isAuth = false;
         state.role = null;
         state.error = null;
+      })
+      .addCase(logoutUser.rejected, (state) => {
+        state.status = 'idle';
+        state.name = null;
+        state.email = null;
+        state.isAuth = false;
+        state.role = null;
       });
   },
 });

--- a/src/store/user/thunk.js
+++ b/src/store/user/thunk.js
@@ -5,26 +5,6 @@ import {
   logoutUserService,
 } from '../../services';
 
-const LS_KEYS = {
-  token: 'userToken',
-  name: 'userName',
-  email: 'userEmail',
-  isAuth: 'isAuth',
-  role: 'userRole',
-};
-
-const persistUserToStorage = (userData) => {
-  localStorage.setItem(LS_KEYS.token, userData.token);
-  localStorage.setItem(LS_KEYS.name, userData.name);
-  localStorage.setItem(LS_KEYS.email, userData.email);
-  localStorage.setItem(LS_KEYS.isAuth, 'true');
-  localStorage.setItem(LS_KEYS.role, userData.role);
-};
-
-const clearUserFromStorage = () => {
-  Object.values(LS_KEYS).forEach((key) => localStorage.removeItem(key));
-};
-
 export const fetchUser = createAsyncThunk(
   'user/fetchUser',
   async (_, { rejectWithValue }) => {
@@ -50,22 +30,12 @@ export const loginUser = createAsyncThunk(
       const result = response.data;
 
       if (result.successful && result.result) {
-        // NOTE: the role should come from the backend (result.user.role).
-        // The current backend mock does not return it yet, so for now
-        // we keep the fallback. Once the backend starts returning the role,
-        // it will be enough to remove this fallback — one place, one change.
-        const role = result.user.role || 'user';
 
-        const userData = {
+        return {
           name: result.user.name,
-          token: result.result,
           email: result.user.email,
-          isAuth: true,
-          role,
+          role: result.user.role
         };
-
-        persistUserToStorage(userData);
-        return userData;
       }
 
       throw new Error(result.message || 'An error occurred while logging in.');
@@ -81,11 +51,12 @@ export const logoutUser = createAsyncThunk(
   'user/logoutUser',
   async (_, { rejectWithValue }) => {
     try {
+      // Backend czyści httpOnly cookie przez Set-Cookie z maxAge: 0
       await logoutUserService();
-      clearUserFromStorage();
       return null;
     } catch (error) {
-      clearUserFromStorage();
+      // Nawet jeśli request się nie powiedzie, czyścimy stan Redux.
+      // Cookie po stronie serwera wygaśnie samoistnie po maxAge.
       return rejectWithValue(
         error.message || 'An error occurred while logging out.'
       );


### PR DESCRIPTION
- backend-mock: add cookie-parser, set httpOnly cookie on /login, clear cookie on /logout, read token from cookie in /users/me
- services: add withCredentials: true, remove manual Authorization header interceptor
- user/thunk: remove persistUserToStorage and clearUserFromStorage, frontend no longer has access to auth token
- user/reducer: remove loadUserFromStorage, add 'bootstrapping' initial status, fetchUser.rejected resets to guest state without error (expected 401 flow)
- App: add bootstrapping guard to block routing until fetchUser resolves, prevents redirect flash on page refresh

BREAKING CHANGE: clears all existing localStorage auth keys on first load