### PR TITLE
refactor(store): introduce user selectors to centralize role logic

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,14 +11,16 @@ import CourseForm from './components/CourseForm/CourseForm';
 import { fetchCourses } from './store/courses/thunk';
 import { fetchAuthors } from './store/authors/thunk';
 import { fetchUser } from './store/user/thunk';
+import { selectIsAuth, selectUserStatus } from './store/user/selectors';
 
 import './App.css';
 
 function App() {
   const dispatch = useDispatch();
-  const user = useSelector((state) => state.user);
-  const isBootstrapping = user.status === 'bootstrapping';
-  const defaultPath = user.isAuth ? '/courses' : '/login';
+  const isAuth = useSelector(selectIsAuth);
+  const userStatus = useSelector(selectUserStatus);
+  const isBootstrapping = userStatus === 'bootstrapping';
+  const defaultPath = isAuth ? '/courses' : '/login';
 
   useEffect(() => {
     dispatch(fetchUser());
@@ -47,7 +49,7 @@ function App() {
           <Route path="/login" element={<Login />} />
           <Route
             path="/courses"
-            element={user.isAuth ? <Courses /> : <Navigate to="/login" />}
+            element={isAuth ? <Courses /> : <Navigate to="/login" />}
           />
           <Route
             path="/courses/add"
@@ -59,9 +61,7 @@ function App() {
           />
           <Route
             path="/courses/:courseId"
-            element={
-              user.isAuth ? <CourseInfo /> : <Navigate to="/login" />
-            }
+            element={isAuth ? <CourseInfo /> : <Navigate to="/login" />}
           />
           <Route
             path="/courses/update/:courseId"

--- a/src/components/Courses/Courses.jsx
+++ b/src/components/Courses/Courses.jsx
@@ -5,16 +5,16 @@ import CourseCard from './components/CourseCard/CourseCard';
 import SearchBar from './components/SearchBar/SearchBar';
 import Button from '../../common/Button/Button';
 import EmptyCourseList from './components/EmptyCourseList';
+import { selectIsAdmin } from '../../store/user/selectors';
 import { ADD_NEW_COURSE_LABEL } from '../../constants/ui';
 import './Courses.css';
 
 function Courses() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const isAdmin = useSelector(selectIsAdmin);
   const courses = useSelector((state) => state.courses.courses);
   const authors = useSelector((state) => state.authors.authors);
-  const user = useSelector((state) => state.user);
-
   const coursesStatus = useSelector((state) => state.courses.status);
   const authorsStatus = useSelector((state) => state.authors.status);
   const isLoading = coursesStatus === 'loading' || authorsStatus === 'loading';
@@ -60,9 +60,9 @@ function Courses() {
           />
         ))
       ) : (
-        <EmptyCourseList role={user.role} />
+        <EmptyCourseList isAdmin={isAdmin} />
       )}
-      {user.role === 'admin' && (
+      {isAdmin && (
         <Button
           label={ADD_NEW_COURSE_LABEL}
           className="ButtonAdd"

--- a/src/components/Courses/components/CourseCard/CourseCard.jsx
+++ b/src/components/Courses/components/CourseCard/CourseCard.jsx
@@ -5,6 +5,7 @@ import Button from '../../../../common/Button/Button';
 import { deleteCourse } from '../../../../store/courses/thunk';
 import formatCreationDate from '../../../../helpers/formatCreationDate';
 import getCourseDuration from '../../../../helpers/getCourseDuration';
+import { selectIsAdmin } from '../../../../store/user/selectors';
 import { MAX_AUTHORS_DISPLAY_LENGTH } from '../../../../constants/validation';
 import './CourseCard.css';
 
@@ -27,8 +28,7 @@ const getAuthorsString = (courseAuthors, authors) => {
 function CourseCard({ course, authors, onCourseSelect }) {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const user = useSelector((state) => state.user);
-  const isAdmin = user.role === 'admin';
+  const isAdmin = useSelector(selectIsAdmin);
 
   const handleDelete = () => {
     dispatch(deleteCourse(course.id));

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { logoutUser } from '../../store/user/thunk';
+import { selectIsAuth, selectUserName } from '../../store/user/selectors';
 import { LOGIN_LABEL } from '../../constants/ui';
 import Logo from './components/Logo/Logo';
 import Button from '../../common/Button/Button';
@@ -11,35 +12,39 @@ function Header() {
   const navigate = useNavigate();
   const location = useLocation();
   const dispatch = useDispatch();
-  const user = useSelector((state) => state.user);
+  const isAuth = useSelector(selectIsAuth);
+  const userName = useSelector(selectUserName);
 
   const handleLogout = async () => {
     await dispatch(logoutUser());
     navigate('/login');
   };
 
+  const isAuthPage =
+    location.pathname === '/login' ||
+    location.pathname === '/registration';
+
   return (
     <div className="Header">
       <Logo />
-      {location.pathname !== '/login' &&
-        location.pathname !== '/registration' && (
-          <>
-            {user.name && <div className="Hello">Hello, {user.name}</div>}
-            {user.isAuth ? (
-              <Button
-                label="Logout"
-                className="ButtonHeader"
-                onClick={handleLogout}
-              />
-            ) : (
-              <Button
-                label={LOGIN_LABEL}
-                className="ButtonHeader"
-                onClick={() => navigate('/login')}
-              />
-            )}
-          </>
-        )}
+      {!isAuthPage && (
+        <>
+          {userName && <div className="Hello">Hello, {userName}</div>}
+          {isAuth ? (
+            <Button
+              label="Logout"
+              className="ButtonHeader"
+              onClick={handleLogout}
+            />
+          ) : (
+            <Button
+              label={LOGIN_LABEL}
+              className="ButtonHeader"
+              onClick={() => navigate('/login')}
+            />
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/PrivateRoute/PrivateRoute.jsx
+++ b/src/components/PrivateRoute/PrivateRoute.jsx
@@ -1,15 +1,17 @@
 import { Navigate, useLocation } from 'react-router-dom';
 import { useSelector } from 'react-redux';
+import { selectIsAuth, selectIsAdmin } from '../../store/user/selectors';
 
 const PrivateRoute = ({ children }) => {
-  const { isAuth, role } = useSelector((state) => state.user);
+  const isAuth = useSelector(selectIsAuth);
+  const isAdmin = useSelector(selectIsAdmin);
   const location = useLocation();
 
   if (!isAuth) {
     return <Navigate to={`/login?redirect=${location.pathname}`} replace />;
   }
 
-  if (role !== 'admin') {
+  if (!isAdmin) {
     return <Navigate to="/courses" replace />;
   }
 

--- a/src/store/user/selectors.js
+++ b/src/store/user/selectors.js
@@ -1,0 +1,6 @@
+export const selectUser = (state) => state.user;
+export const selectIsAuth = (state) => state.user.isAuth;
+export const selectIsAdmin = (state) => state.user.role === 'admin';
+export const selectUserName = (state) => state.user.name;
+export const selectUserRole = (state) => state.user.role;
+export const selectUserStatus = (state) => state.user.status;


### PR DESCRIPTION
- store/user/selectors.js: new file with selectIsAuth, selectIsAdmin, selectUserName, selectUserRole, selectUserStatus
- remove all direct role === 'admin' comparisons from components
- App, PrivateRoute, Header, Courses, CourseCard: import and use selectors
- Header: extract isAuthPage variable instead of inline double comparison
- Courses: pass isAdmin prop to EmptyCourseList instead of user object