### PR TITLE
refactor(CourseForm): encapsulate form state with register() pattern

### DIFF
--- a/src/components/CourseForm/CourseForm.jsx
+++ b/src/components/CourseForm/CourseForm.jsx
@@ -4,46 +4,34 @@ import Button from '../../common/Button/Button';
 import useCourseForm from './hooks/useCourseForm';
 
 function CourseForm() {
-  const { fields, setters, state, handlers } = useCourseForm();
-
-  const { title, description, duration, newAuthorName } = fields;
-  const { setTitle, setDescription, setDuration, setNewAuthorName } = setters;
   const {
+    register,
     errors,
     isSaving,
     courseAuthors,
     availableAuthors,
     submitLabel,
-  } = state;
-  const {
     handleSubmit,
     handleCreateAuthor,
     handleAddAuthorToCourse,
     handleRemoveAuthorFromCourse,
-  } = handlers;
+  } = useCourseForm();
 
   return (
     <div className="CreateCourse">
       <label>
         Title:
-        <input value={title} onChange={(e) => setTitle(e.target.value)} />
+        <input {...register('title')} />
         <p className="error-message">{errors.title || ' '}</p>
       </label>
       <label>
         Description:
-        <textarea
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-        />
+        <textarea {...register('description')} />
         <p className="error-message">{errors.description || ' '}</p>
       </label>
       <label>
         Duration:
-        <input
-          type="number"
-          value={duration}
-          onChange={(e) => setDuration(e.target.value)}
-        />
+        <input type="number" {...register('duration')} />
         <p className="error-message">{errors.duration || ' '}</p>
       </label>
       <div>
@@ -72,10 +60,7 @@ function CourseForm() {
       </div>
       <label>
         New Author:
-        <input
-          value={newAuthorName}
-          onChange={(e) => setNewAuthorName(e.target.value)}
-        />
+        <input {...register('newAuthorName')} />
         <p className="error-message">{errors.newAuthorName || ' '}</p>
         <Button onClick={handleCreateAuthor} label="Create Author" />
       </label>

--- a/src/components/CourseForm/hooks/useCourseForm.js
+++ b/src/components/CourseForm/hooks/useCourseForm.js
@@ -28,11 +28,13 @@ const validateCourseFields = ({ title, description, duration }) => {
 };
 
 const useCourseForm = () => {
-  const [title, setTitle] = useState('');
-  const [description, setDescription] = useState('');
-  const [duration, setDuration] = useState('');
+  const [fields, setFields] = useState({
+    title: '',
+    description: '',
+    duration: '',
+    newAuthorName: '',
+  });
   const [courseAuthors, setCourseAuthors] = useState([]);
-  const [newAuthorName, setNewAuthorName] = useState('');
   const [errors, setErrors] = useState({});
 
   const navigate = useNavigate();
@@ -52,11 +54,23 @@ const useCourseForm = () => {
     const courseToUpdate = courses.find((course) => course.id === courseId);
     if (!courseToUpdate) return;
 
-    setTitle(courseToUpdate.title);
-    setDescription(courseToUpdate.description);
-    setDuration(courseToUpdate.duration);
+    setFields({
+      title: courseToUpdate.title,
+      description: courseToUpdate.description,
+      duration: courseToUpdate.duration,
+      newAuthorName: '',
+    });
     setCourseAuthors(courseToUpdate.authors);
   }, [courses, courseId]);
+
+  // register() zwraca props gotowe do spread'owania na element formularza.
+  // Komponent nie obsługuje e.target.value — hook robi to wewnętrznie.
+  // Wzorzec popularyzowany przez react-hook-form.
+  const register = (fieldName) => ({
+    value: fields[fieldName],
+    onChange: (e) =>
+      setFields((prev) => ({ ...prev, [fieldName]: e.target.value })),
+  });
 
   const handleAddAuthorToCourse = (authorId) => {
     setCourseAuthors((prev) => [...prev, authorId]);
@@ -67,7 +81,7 @@ const useCourseForm = () => {
   };
 
   const handleCreateAuthor = async () => {
-    if (newAuthorName.length < MIN_AUTHOR_NAME_LENGTH) {
+    if (fields.newAuthorName.length < MIN_AUTHOR_NAME_LENGTH) {
       setErrors((prev) => ({
         ...prev,
         newAuthorName: `Author name should be at least ${MIN_AUTHOR_NAME_LENGTH} characters`,
@@ -75,10 +89,10 @@ const useCourseForm = () => {
       return;
     }
 
-    const result = await dispatch(createAuthor({ name: newAuthorName }));
+    const result = await dispatch(createAuthor({ name: fields.newAuthorName }));
 
     if (createAuthor.fulfilled.match(result)) {
-      setNewAuthorName('');
+      setFields((prev) => ({ ...prev, newAuthorName: '' }));
       setErrors((prev) => ({ ...prev, newAuthorName: null }));
     } else {
       setErrors((prev) => ({
@@ -90,7 +104,7 @@ const useCourseForm = () => {
   };
 
   const handleCreateCourse = async () => {
-    const validationErrors = validateCourseFields({ title, description, duration });
+    const validationErrors = validateCourseFields(fields);
 
     if (Object.keys(validationErrors).length) {
       setErrors(validationErrors);
@@ -98,9 +112,9 @@ const useCourseForm = () => {
     }
 
     const newCourse = {
-      title,
-      description,
-      duration: Number(duration),
+      title: fields.title,
+      description: fields.description,
+      duration: Number(fields.duration),
       authors: courseAuthors,
     };
 
@@ -117,7 +131,7 @@ const useCourseForm = () => {
   };
 
   const handleUpdateCourse = async () => {
-    const validationErrors = validateCourseFields({ title, description, duration });
+    const validationErrors = validateCourseFields(fields);
 
     if (Object.keys(validationErrors).length) {
       setErrors(validationErrors);
@@ -126,9 +140,9 @@ const useCourseForm = () => {
 
     const updatedCourse = {
       id: courseId,
-      title,
-      description,
-      duration: Number(duration),
+      title: fields.title,
+      description: fields.description,
+      duration: Number(fields.duration),
       authors: courseAuthors,
     };
 
@@ -156,32 +170,17 @@ const useCourseForm = () => {
     : 'Create Course';
 
   return {
-    fields: {
-      title,
-      description,
-      duration,
-      newAuthorName,
-    },
-    setters: {
-      setTitle,
-      setDescription,
-      setDuration,
-      setNewAuthorName,
-    },
-    state: {
-      errors,
-      isSaving,
-      isEditMode,
-      courseAuthors,
-      availableAuthors,
-      submitLabel,
-    },
-    handlers: {
-      handleSubmit,
-      handleCreateAuthor,
-      handleAddAuthorToCourse,
-      handleRemoveAuthorFromCourse,
-    },
+    register,
+    errors,
+    isSaving,
+    isEditMode,
+    courseAuthors,
+    availableAuthors,
+    submitLabel,
+    handleSubmit,
+    handleCreateAuthor,
+    handleAddAuthorToCourse,
+    handleRemoveAuthorFromCourse,
   };
 };
 


### PR DESCRIPTION
- useCourseForm: replace four separate useState calls with single fields object
- useCourseForm: add register(fieldName) returning { value, onChange } ready to spread on form elements — component no longer handles e.target.value
- useCourseForm: flatten returned API from nested fields/setters/state/handlers to a single flat object — cleaner destructuring in consuming component
- CourseForm: replace manual onChange handlers with spread register() calls, component is now a pure view with zero form logic