### PR TITLE
feat(ui): add error state handling with reusable ErrorMessage component

### DIFF
--- a/src/common/ErrorMessage/ErrorMessage.css
+++ b/src/common/ErrorMessage/ErrorMessage.css
@@ -1,0 +1,14 @@
+.error-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 2rem;
+  text-align: center;
+}
+
+.error-container__message {
+  color: #c0392b;
+  font-size: 1rem;
+  margin: 0;
+}

--- a/src/common/ErrorMessage/ErrorMessage.jsx
+++ b/src/common/ErrorMessage/ErrorMessage.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Button from '../Button/Button';
+import './ErrorMessage.css';
+
+function ErrorMessage({ message, onRetry }) {
+  return (
+    <div className="error-container">
+      <p className="error-container__message">
+        {message || 'Something went wrong. Please try again.'}
+      </p>
+      {onRetry && (
+        <Button label="Try again" onClick={onRetry} className="error-container__retry" />
+      )}
+    </div>
+  );
+}
+
+ErrorMessage.propTypes = {
+  message: PropTypes.string,
+  onRetry: PropTypes.func,
+};
+
+export default ErrorMessage;

--- a/src/components/CourseInfo/CourseInfo.jsx
+++ b/src/components/CourseInfo/CourseInfo.jsx
@@ -1,28 +1,41 @@
 import React from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import formatCreationDate from '../../helpers/formatCreationDate';
 import getCourseDuration from '../../helpers/getCourseDuration';
+import ErrorMessage from '../../common/ErrorMessage/ErrorMessage';
+import { fetchCourses } from '../../store/courses/thunk';
 import './CourseInfo.css';
-
-const COURSE_INFO_LOADING_MESSAGE = 'Loading course...';
-const COURSE_INFO_NOT_FOUND_MESSAGE = 'Course not found.';
 
 function CourseInfo() {
   const { courseId } = useParams();
+  const dispatch = useDispatch();
 
   const coursesStatus = useSelector((state) => state.courses.status);
+  const coursesError = useSelector((state) => state.courses.error);
   const authorsStatus = useSelector((state) => state.authors.status);
   const courses = useSelector((state) => state.courses.courses);
   const authors = useSelector((state) => state.authors.authors);
 
-  const isLoading =
-    coursesStatus === 'loading' || authorsStatus === 'loading';
+  const isLoading = coursesStatus === 'loading' || authorsStatus === 'loading';
+  const hasFailed = coursesStatus === 'failed';
+
+  const handleRetry = () => {
+    dispatch(fetchCourses());
+  };
 
   if (isLoading) {
     return (
       <div className="Course-all">
-        <p>{COURSE_INFO_LOADING_MESSAGE}</p>
+        <p>Loading course...</p>
+      </div>
+    );
+  }
+
+  if (hasFailed) {
+    return (
+      <div className="Course-all">
+        <ErrorMessage message={coursesError} onRetry={handleRetry} />
       </div>
     );
   }
@@ -32,7 +45,7 @@ function CourseInfo() {
   if (!course) {
     return (
       <div className="Course-all">
-        <p>{COURSE_INFO_NOT_FOUND_MESSAGE}</p>
+        <p>Course not found.</p>
         <Link to="/courses" className="back-button">
           Back to Courses
         </Link>

--- a/src/components/Courses/Courses.jsx
+++ b/src/components/Courses/Courses.jsx
@@ -5,7 +5,9 @@ import CourseCard from './components/CourseCard/CourseCard';
 import SearchBar from './components/SearchBar/SearchBar';
 import Button from '../../common/Button/Button';
 import EmptyCourseList from './components/EmptyCourseList';
+import ErrorMessage from '../../common/ErrorMessage/ErrorMessage';
 import { selectIsAdmin } from '../../store/user/selectors';
+import { fetchCourses } from '../../store/courses/thunk';
 import { ADD_NEW_COURSE_LABEL } from '../../constants/ui';
 import './Courses.css';
 
@@ -16,8 +18,10 @@ function Courses() {
   const courses = useSelector((state) => state.courses.courses);
   const authors = useSelector((state) => state.authors.authors);
   const coursesStatus = useSelector((state) => state.courses.status);
+  const coursesError = useSelector((state) => state.courses.error);
   const authorsStatus = useSelector((state) => state.authors.status);
   const isLoading = coursesStatus === 'loading' || authorsStatus === 'loading';
+  const hasFailed = coursesStatus === 'failed';
 
   const [query, setQuery] = useState('');
 
@@ -39,10 +43,22 @@ function Courses() {
     navigate(`/courses/${course.id}`);
   };
 
+  const handleRetry = () => {
+    dispatch(fetchCourses());
+  };
+
   if (isLoading) {
     return (
       <div className="Courses">
         <p className="loading-message">Loading courses...</p>
+      </div>
+    );
+  }
+
+  if (hasFailed) {
+    return (
+      <div className="Courses">
+        <ErrorMessage message={coursesError} onRetry={handleRetry} />
       </div>
     );
   }


### PR DESCRIPTION
- common/ErrorMessage: new reusable component with optional retry button, used wherever async data fetching can fail
- Courses: handle status === 'failed' with ErrorMessage and retry action dispatching fetchCourses — previously showed empty list silently
- CourseInfo: handle status === 'failed' with ErrorMessage and retry action, keep 'not found' case separate from fetch error case