### PR TITLE
perf(useCourseForm): remove redundant fetchAuthors after createAuthor

### DIFF
--- a/src/components/CourseForm/hooks/useCourseForm.js
+++ b/src/components/CourseForm/hooks/useCourseForm.js
@@ -63,9 +63,6 @@ const useCourseForm = () => {
     setCourseAuthors(courseToUpdate.authors);
   }, [courses, courseId]);
 
-  // register() zwraca props gotowe do spread'owania na element formularza.
-  // Komponent nie obsługuje e.target.value — hook robi to wewnętrznie.
-  // Wzorzec popularyzowany przez react-hook-form.
   const register = (fieldName) => ({
     value: fields[fieldName],
     onChange: (e) =>


### PR DESCRIPTION
authorsSlice already handles createAuthor.fulfilled by pushing the new author into store — dispatching fetchAuthors immediately after is an unnecessary network round-trip that fetches data we already have locally.

Also removes the now-unused fetchAuthors import from the hook.