### PR TITLE
refactor: convert CourseCard to dumb component, lift logic to Courses

### DIFF
--- a/src/components/Courses/Courses.jsx
+++ b/src/components/Courses/Courses.jsx
@@ -13,7 +13,7 @@ import {
   selectCoursesError,
 } from '../../store/courses/selectors';
 import { selectAuthors, selectAuthorsStatus } from '../../store/authors/selectors';
-import { fetchCourses } from '../../store/courses/thunk';
+import { fetchCourses, deleteCourse } from '../../store/courses/thunk';
 import { ADD_NEW_COURSE_LABEL } from '../../constants/ui';
 import './Courses.css';
 
@@ -47,6 +47,14 @@ function Courses() {
     navigate(`/courses/${course.id}`);
   };
 
+  const handleDelete = (courseId) => {
+    dispatch(deleteCourse(courseId));
+  };
+
+  const handleUpdate = (courseId) => {
+    navigate(`/courses/update/${courseId}`);
+  };
+
   const handleRetry = () => {
     dispatch(fetchCourses());
   };
@@ -76,7 +84,10 @@ function Courses() {
             key={course.id}
             course={course}
             authors={authors}
+            isAdmin={isAdmin}
             onCourseSelect={handleCourseSelect}
+            onDelete={handleDelete}
+            onUpdate={handleUpdate}
           />
         ))
       ) : (

--- a/src/components/Courses/components/CourseCard/CourseCard.jsx
+++ b/src/components/Courses/components/CourseCard/CourseCard.jsx
@@ -1,28 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useDispatch, useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
 import Button from '../../../../common/Button/Button';
-import { deleteCourse } from '../../../../store/courses/thunk';
 import formatCreationDate from '../../../../helpers/formatCreationDate';
 import getCourseDuration from '../../../../helpers/getCourseDuration';
 import getAuthorNames from '../../../../helpers/getAuthorNames';
-import { selectIsAdmin } from '../../../../store/user/selectors';
 import './CourseCard.css';
 
-function CourseCard({ course, authors, onCourseSelect }) {
-  const dispatch = useDispatch();
-  const navigate = useNavigate();
-  const isAdmin = useSelector(selectIsAdmin);
-
-  const handleDelete = () => {
-    dispatch(deleteCourse(course.id));
-  };
-
-  const handleUpdate = () => {
-    navigate(`/courses/update/${course.id}`);
-  };
-
+function CourseCard({ course, authors, onCourseSelect, onDelete, onUpdate, isAdmin }) {
   return (
     <div className="Course-card">
       <div className="Course-rect">
@@ -46,12 +30,12 @@ function CourseCard({ course, authors, onCourseSelect }) {
               <Button
                 label="DELETE"
                 className="Course-button"
-                onClick={handleDelete}
+                onClick={() => onDelete(course.id)}
               />
               <Button
                 label="UPDATE"
                 className="Course-button"
-                onClick={handleUpdate}
+                onClick={() => onUpdate(course.id)}
               />
             </>
           )}
@@ -76,7 +60,10 @@ CourseCard.propTypes = {
       name: PropTypes.string.isRequired,
     })
   ).isRequired,
+  isAdmin: PropTypes.bool.isRequired,
   onCourseSelect: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired,
 };
 
 export default CourseCard;


### PR DESCRIPTION
- Remove useDispatch, useSelector, useNavigate from CourseCard
- Add onDelete, onUpdate, isAdmin props to CourseCard interface
- Move deleteCourse dispatch and update navigation to Courses.jsx
- CourseCard is now a pure presentational component — no store dependency
- Simplifies CourseCard testing: no Redux provider needed