### PR TITLE
fix: add missing CourseForm.css and import it in CourseForm

### DIFF
--- a/src/components/CourseForm/CourseForm.css
+++ b/src/components/CourseForm/CourseForm.css
@@ -1,0 +1,61 @@
+.CreateCourse {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+.CreateCourse label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #333;
+}
+
+.CreateCourse input,
+.CreateCourse textarea {
+  padding: 8px 12px;
+  font-size: 14px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.CreateCourse input:focus,
+.CreateCourse textarea:focus {
+  border-color: #555;
+}
+
+.CreateCourse textarea {
+  min-height: 100px;
+  resize: vertical;
+}
+
+.CreateCourse input[type='number'] {
+  width: 120px;
+}
+
+.CreateCourse .error-message {
+  font-size: 12px;
+  color: #c0392b;
+  min-height: 18px;
+  margin: 0;
+}
+
+.CreateCourse .authors-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.CreateCourse .authors-section__title {
+  font-size: 14px;
+  font-weight: 500;
+  color: #333;
+  margin: 0;
+}

--- a/src/components/CourseForm/CourseForm.jsx
+++ b/src/components/CourseForm/CourseForm.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import AuthorItem from './components/AuthorItem/AuthorItem';
 import Button from '../../common/Button/Button';
 import useCourseForm from './hooks/useCourseForm';
+import './CourseForm.css';
 
 function CourseForm() {
   const {
@@ -34,7 +35,8 @@ function CourseForm() {
         <input type="number" {...register('duration')} />
         <p className="error-message">{errors.duration || ' '}</p>
       </label>
-      <div>
+      <div className="authors-section">
+        <p className="authors-section__title">Available authors:</p>
         {availableAuthors.map((author) => (
           <AuthorItem
             key={author.id}
@@ -44,7 +46,8 @@ function CourseForm() {
           />
         ))}
       </div>
-      <div>
+      <div className="authors-section">
+        <p className="authors-section__title">Course authors:</p>
         {courseAuthors.map((authorId) => {
           const author = availableAuthors.find((a) => a.id === authorId);
           if (!author) return null;


### PR DESCRIPTION
- Create CourseForm.css with explicit styles for form layout, inputs, labels
- Add authors-section and authors-section__title classes to replace implicit globals
- Import CourseForm.css in CourseForm.jsx — styles no longer rely on global leakage
- Consistent with CSS pattern used by all other components in the project