### PR TITLE
fix: add React.StrictMode and guard getCourseDuration against invalid…

### DIFF
--- a/src/helpers/getCourseDuration.js
+++ b/src/helpers/getCourseDuration.js
@@ -1,6 +1,12 @@
 const getCourseDuration = (duration) => {
-  const hours = Math.floor(duration / 60);
-  const minutes = duration % 60;
+  const value = Number(duration);
+
+  if (!Number.isFinite(value) || value <= 0) {
+    return 'N/A';
+  }
+
+  const hours = Math.floor(value / 60);
+  const minutes = value % 60;
   const formattedHours = String(hours).padStart(2, '0');
   const formattedMinutes = String(minutes).padStart(2, '0');
   const label = hours === 1 ? 'hour' : 'hours';

--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,11 @@ const root = document.getElementById('root');
 const appRoot = createRoot(root);
 
 appRoot.render(
-  <Provider store={store}>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </Provider>
+  <React.StrictMode>
+    <Provider store={store}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </Provider>
+  </React.StrictMode>
 );


### PR DESCRIPTION
… input

- Wrap app root with React.StrictMode to catch deprecated API usage in dev
- StrictMode covers full tree including Provider and BrowserRouter
- getCourseDuration: convert input with Number() before calculation
- getCourseDuration: return N/A for null, undefined, NaN, zero and negative values
- Prevents NaN:NaN hours rendering when API returns missing duration field