### PR TITLE
fix: restore axios interceptor with 401 handling and error logging

### DIFF
--- a/src/services.js
+++ b/src/services.js
@@ -9,6 +9,19 @@ const apiClient = axios.create({
 apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
+    const status = error.response?.status;
+
+    if (status === 401) {
+      window.location.href = '/login';
+    }
+
+    if (process.env.NODE_ENV !== 'test') {
+      console.error(
+        `[API Error] ${error.config?.method?.toUpperCase()} ${error.config?.url} — ${status ?? 'network error'}`,
+        error.message
+      );
+    }
+
     return Promise.reject(error);
   }
 );


### PR DESCRIPTION
- Handle 401 Unauthorized with redirect to /login (expired session)
- Log all API errors centrally with method, url and status code
- Skip console.error in test environment to keep test output clean
- Replaces no-op interceptor that duplicated Axios default behaviour