### PR TITLE
fix: course authors section empty when editing existing course

### DIFF
--- a/src/components/CourseForm/CourseForm.jsx
+++ b/src/components/CourseForm/CourseForm.jsx
@@ -9,7 +9,7 @@ function CourseForm() {
     register,
     errors,
     isSaving,
-    courseAuthors,
+    courseAuthorObjects,
     availableAuthors,
     submitLabel,
     handleSubmit,
@@ -48,18 +48,14 @@ function CourseForm() {
       </div>
       <div className="authors-section">
         <p className="authors-section__title">Course authors:</p>
-        {courseAuthors.map((authorId) => {
-          const author = availableAuthors.find((a) => a.id === authorId);
-          if (!author) return null;
-          return (
-            <AuthorItem
-              key={authorId}
-              author={author}
-              onAction={() => handleRemoveAuthorFromCourse(authorId)}
-              action="Delete"
-            />
-          );
-        })}
+        {courseAuthorObjects.map((author) => (
+          <AuthorItem
+            key={author.id}
+            author={author}
+            onAction={() => handleRemoveAuthorFromCourse(author.id)}
+            action="Delete"
+          />
+        ))}
       </div>
       <label>
         New Author:

--- a/src/components/CourseForm/hooks/useCourseForm.js
+++ b/src/components/CourseForm/hooks/useCourseForm.js
@@ -140,6 +140,10 @@ const useCourseForm = () => {
     (author) => !courseAuthors.includes(author.id)
   );
 
+  const courseAuthorObjects = courseAuthors
+    .map((id) => authors.find((a) => a.id === id))
+    .filter(Boolean);
+
   const submitLabel = isSaving
     ? 'Saving...'
     : isEditMode
@@ -151,7 +155,7 @@ const useCourseForm = () => {
     errors,
     isSaving,
     isEditMode,
-    courseAuthors,
+    courseAuthorObjects,
     availableAuthors,
     submitLabel,
     handleSubmit,


### PR DESCRIPTION
- Add courseAuthorObjects to useCourseForm — resolves assigned author IDs to full author objects using the complete authors list, not availableAuthors
- Replace courseAuthors.map + availableAuthors.find pattern in CourseForm with direct iteration over courseAuthorObjects
- Fixes bug where assigned authors disappeared from 'Course authors' section because availableAuthors only contains authors not yet assigned