### PR TITLE
fix: replace REACT_APP_API_URL with VITE_API_URL in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,17 @@
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --ignore-scripts --silent
+
+COPY . ./
+
+ARG VITE_API_URL=/api
+ENV VITE_API_URL=$VITE_API_URL
+
+RUN npm run build
+
 FROM node:18-alpine
 
 WORKDIR /app
@@ -7,18 +21,12 @@ WORKDIR /app/backend
 RUN npm ci --only=production --silent
 
 WORKDIR /app
-COPY package*.json ./
-RUN npm ci --ignore-scripts --silent
-COPY . ./
-ENV REACT_APP_API_URL=/api
-RUN npm run build
-
-WORKDIR /app
 RUN npm init -y
 RUN npm install express json-server --save
 
 COPY backend-mock/db.json ./db.json
 COPY server-railway.js ./server.js
+COPY --from=builder /app/build ./build
 
 EXPOSE 3000
 

--- a/Dockerfile.multi-container
+++ b/Dockerfile.multi-container
@@ -1,13 +1,22 @@
-FROM node:18-alpine AS build
+FROM node:18-alpine AS builder
+
 WORKDIR /app
+
 COPY package*.json ./
-RUN npm ci --ignore-scripts 
-COPY . .
-ENV REACT_APP_API_URL=/api
+RUN npm ci --ignore-scripts --silent
+
+COPY . ./
+
+ARG VITE_API_URL=/api
+ENV VITE_API_URL=$VITE_API_URL
+
 RUN npm run build
 
 FROM nginx:alpine
-COPY --from=build /app/build /usr/share/nginx/html
+
+COPY --from=builder /app/build /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+
 EXPOSE 80
+
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
- Vite reads VITE_* env vars at build time, not REACT_APP_* (CRA prefix)
- Use ARG + ENV pattern so URL can be overridden at docker build time: docker build --build-arg VITE_API_URL=https://api.example.com .
- Refactor Dockerfile to multi-stage build: builder stage installs frontend deps and builds, final stage only contains server deps and built assets
- Previous setup relied on /api fallback in config.js — now explicit