### PR TITLE
refactor: extract auth form logic into custom hooks

### DIFF
--- a/src/components/Login/Login.jsx
+++ b/src/components/Login/Login.jsx
@@ -1,56 +1,12 @@
-import React, { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
-import { useDispatch, useSelector } from 'react-redux';
+import React from 'react';
+import { Link } from 'react-router-dom';
 import Input from '../../common/Input/Input';
 import Button from '../../common/Button/Button';
-import { loginUser } from '../../store/user/thunk';
-import { selectUserStatus } from '../../store/user/selectors';
+import useLoginForm from './hooks/useLoginForm';
 
 function Login() {
-  const [formData, setFormData] = useState({
-    email: '',
-    password: '',
-  });
-  const [errors, setErrors] = useState({});
-  const navigate = useNavigate();
-  const dispatch = useDispatch();
-
-  const status = useSelector(selectUserStatus);
-  const isLoading = status === 'loading';
-
-  const handleChange = (e) => {
-    const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
-  };
-
-  const validate = () => {
-    const validationErrors = {};
-    if (!formData.email) validationErrors.email = 'Email is required';
-    if (!formData.password) validationErrors.password = 'Password is required';
-    return validationErrors;
-  };
-
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-
-    const validationErrors = validate();
-    if (Object.keys(validationErrors).length) {
-      setErrors(validationErrors);
-      return;
-    }
-
-    const resultAction = await dispatch(loginUser(formData));
-
-    if (loginUser.fulfilled.match(resultAction)) {
-      navigate('/courses', { replace: true });
-    } else {
-      setErrors({
-        server:
-          resultAction.payload ||
-          'An error occurred while logging in. Please try again.',
-      });
-    }
-  };
+  const { formData, errors, isLoading, handleChange, handleSubmit } =
+    useLoginForm();
 
   return (
     <form onSubmit={handleSubmit}>

--- a/src/components/Login/hooks/useLoginForm.js
+++ b/src/components/Login/hooks/useLoginForm.js
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { loginUser } from '../../../store/user/thunk';
+import { selectUserStatus } from '../../../store/user/selectors';
+
+const validate = (formData) => {
+  const errors = {};
+  if (!formData.email) errors.email = 'Email is required';
+  if (!formData.password) errors.password = 'Password is required';
+  return errors;
+};
+
+const useLoginForm = () => {
+  const [formData, setFormData] = useState({ email: '', password: '' });
+  const [errors, setErrors] = useState({});
+
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+
+  const status = useSelector(selectUserStatus);
+  const isLoading = status === 'loading';
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    const validationErrors = validate(formData);
+    if (Object.keys(validationErrors).length) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    const result = await dispatch(loginUser(formData));
+
+    if (loginUser.fulfilled.match(result)) {
+      navigate('/courses', { replace: true });
+    } else {
+      setErrors({
+        server:
+          result.payload ||
+          'An error occurred while logging in. Please try again.',
+      });
+    }
+  };
+
+  return {
+    formData,
+    errors,
+    isLoading,
+    handleChange,
+    handleSubmit,
+  };
+};
+
+export default useLoginForm;

--- a/src/components/Registration/Registration.jsx
+++ b/src/components/Registration/Registration.jsx
@@ -1,58 +1,12 @@
-import React, { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
-import { useDispatch, useSelector } from 'react-redux';
+import React from 'react';
+import { Link } from 'react-router-dom';
 import Button from '../../common/Button/Button';
 import Input from '../../common/Input/Input';
-import { registerUser } from '../../store/user/thunk';
-import { selectUserStatus } from '../../store/user/selectors';
+import useRegistrationForm from './hooks/useRegistrationForm';
 
 function Registration() {
-  const navigate = useNavigate();
-  const dispatch = useDispatch();
-
-  const status = useSelector(selectUserStatus);
-  const isLoading = status === 'loading';
-
-  const [userData, setUserData] = useState({
-    name: '',
-    email: '',
-    password: '',
-  });
-  const [errors, setErrors] = useState({});
-
-  const handleChange = (e) => {
-    const { name, value } = e.target;
-    setUserData((prev) => ({ ...prev, [name]: value }));
-  };
-
-  const validate = () => {
-    const validationErrors = {};
-    if (!userData.name) validationErrors.name = 'Name is required';
-    if (!userData.email) validationErrors.email = 'Email is required';
-    if (!userData.password) validationErrors.password = 'Password is required';
-    return validationErrors;
-  };
-
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-
-    const validationErrors = validate();
-    if (Object.keys(validationErrors).length) {
-      setErrors(validationErrors);
-      return;
-    }
-
-    const resultAction = await dispatch(registerUser(userData));
-
-    if (registerUser.fulfilled.match(resultAction)) {
-      navigate('/login');
-    } else {
-      setErrors({
-        server:
-          resultAction.payload || 'Registration failed. Please try again.',
-      });
-    }
-  };
+  const { userData, errors, isLoading, handleChange, handleSubmit } =
+    useRegistrationForm();
 
   return (
     <form onSubmit={handleSubmit}>

--- a/src/components/Registration/hooks/useRegistrationForm.js
+++ b/src/components/Registration/hooks/useRegistrationForm.js
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { registerUser } from '../../../store/user/thunk';
+import { selectUserStatus } from '../../../store/user/selectors';
+
+const validate = (userData) => {
+  const errors = {};
+  if (!userData.name) errors.name = 'Name is required';
+  if (!userData.email) errors.email = 'Email is required';
+  if (!userData.password) errors.password = 'Password is required';
+  return errors;
+};
+
+const useRegistrationForm = () => {
+  const [userData, setUserData] = useState({
+    name: '',
+    email: '',
+    password: '',
+  });
+  const [errors, setErrors] = useState({});
+
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+
+  const status = useSelector(selectUserStatus);
+  const isLoading = status === 'loading';
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setUserData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    const validationErrors = validate(userData);
+    if (Object.keys(validationErrors).length) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    const result = await dispatch(registerUser(userData));
+
+    if (registerUser.fulfilled.match(result)) {
+      navigate('/login');
+    } else {
+      setErrors({
+        server:
+          result.payload || 'Registration failed. Please try again.',
+      });
+    }
+  };
+
+  return {
+    userData,
+    errors,
+    isLoading,
+    handleChange,
+    handleSubmit,
+  };
+};
+
+export default useRegistrationForm;


### PR DESCRIPTION
- Add useLoginForm hook: formData state, validation, dispatch loginUser, navigate
- Add useRegistrationForm hook: userData state, validation, dispatch registerUser, navigate
- Login.jsx and Registration.jsx reduced to pure JSX — zero business logic
- Consistent with useCourseForm pattern already used in CourseForm
- validate() extracted to module-level function in each hook (not inline)