### PR TITLE
refactor: fetch courses and authors only after successful authentication

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,9 +24,13 @@ function App() {
 
   useEffect(() => {
     dispatch(fetchUser());
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (!isAuth) return;
     dispatch(fetchCourses());
     dispatch(fetchAuthors());
-  }, [dispatch]);
+  }, [dispatch, isAuth]);
 
   if (isBootstrapping) {
     return (


### PR DESCRIPTION
- Split single useEffect into two separate effects with distinct concerns
- fetchUser fires unconditionally — required to restore session on page load
- fetchCourses and fetchAuthors fire only when isAuth is true
- Eliminates two unnecessary API requests for unauthenticated users
- Data re-fetches automatically when isAuth transitions to true after login