### PR TITLE
refactor: unify route protection with single PrivateRoute pattern

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -53,24 +53,32 @@ function App() {
           <Route path="/login" element={<Login />} />
           <Route
             path="/courses"
-            element={isAuth ? <Courses /> : <Navigate to="/login" />}
+            element={
+              <PrivateRoute>
+                <Courses />
+              </PrivateRoute>
+            }
           />
           <Route
             path="/courses/add"
             element={
-              <PrivateRoute>
+              <PrivateRoute requireAdmin>
                 <CourseForm />
               </PrivateRoute>
             }
           />
           <Route
             path="/courses/:courseId"
-            element={isAuth ? <CourseInfo /> : <Navigate to="/login" />}
+            element={
+              <PrivateRoute>
+                <CourseInfo />
+              </PrivateRoute>
+            }
           />
           <Route
             path="/courses/update/:courseId"
             element={
-              <PrivateRoute>
+              <PrivateRoute requireAdmin>
                 <CourseForm />
               </PrivateRoute>
             }

--- a/src/components/PrivateRoute/PrivateRoute.jsx
+++ b/src/components/PrivateRoute/PrivateRoute.jsx
@@ -4,7 +4,7 @@ import { Navigate, useLocation } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { selectIsAuth, selectIsAdmin } from '../../store/user/selectors';
 
-const PrivateRoute = ({ children }) => {
+const PrivateRoute = ({ children, requireAdmin = false }) => {
   const isAuth = useSelector(selectIsAuth);
   const isAdmin = useSelector(selectIsAdmin);
   const location = useLocation();
@@ -13,7 +13,7 @@ const PrivateRoute = ({ children }) => {
     return <Navigate to={`/login?redirect=${location.pathname}`} replace />;
   }
 
-  if (!isAdmin) {
+  if (requireAdmin && !isAdmin) {
     return <Navigate to="/courses" replace />;
   }
 
@@ -22,6 +22,7 @@ const PrivateRoute = ({ children }) => {
 
 PrivateRoute.propTypes = {
   children: PropTypes.node.isRequired,
+  requireAdmin: PropTypes.bool,
 };
 
 export default PrivateRoute;


### PR DESCRIPTION
- Add requireAdmin prop to PrivateRoute (default: false)
- PrivateRoute without requireAdmin: redirects unauthenticated users to login
- PrivateRoute with requireAdmin: additionally redirects non-admin to /courses
- Replace inline isAuth ternaries in App.jsx with PrivateRoute wrapper
- App.jsx routing is now declarative — access level visible at a glance
- Remove isAuth from JSX conditionals — no longer needed for route rendering