### PR TITLE
fix: add HttpOnly cookie auth and middleware to server-railway.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
         "axios": "^1.4.0",
+        "cookie-parser": "^1.4.7",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2197,6 +2198,34 @@
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",
     "axios": "^1.4.0",
+    "cookie-parser": "^1.4.7",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/server-railway.js
+++ b/server-railway.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const cookieParser = require('cookie-parser');
 const jsonServer = require('json-server');
 const path = require('path');
 
@@ -7,6 +8,57 @@ const router = jsonServer.router('db.json');
 const db = router.db;
 
 app.use(express.json());
+app.use(cookieParser());
+
+const AUTH_COOKIE_NAME = 'authToken';
+
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  sameSite: 'lax',
+  maxAge: 24 * 60 * 60 * 1000,
+  secure: process.env.NODE_ENV === 'production',
+};
+
+// --- Auth middleware ---
+
+/**
+ * Verifies that the request carries a valid session cookie.
+ * In production this would verify a signed JWT.
+ * Here it looks up the token in db.json (mock only).
+ */
+const requireAuth = (req, res, next) => {
+  const token = req.cookies[AUTH_COOKIE_NAME];
+
+  if (!token) {
+    return res
+      .status(401)
+      .json({ successful: false, errors: ['No session cookie provided'] });
+  }
+
+  const user = db.get('users').find({ token }).value();
+
+  if (!user) {
+    return res
+      .status(401)
+      .json({ successful: false, errors: ['Invalid or expired session'] });
+  }
+
+  req.user = user;
+  next();
+};
+
+/**
+ * Verifies that the authenticated user has the admin role.
+ * Must be used after requireAuth.
+ */
+const requireAdmin = (req, res, next) => {
+  if (req.user?.role !== 'admin') {
+    return res
+      .status(403)
+      .json({ successful: false, errors: ['Admin access required'] });
+  }
+  next();
+};
 
 // --- User endpoints ---
 
@@ -15,6 +67,8 @@ app.post('/api/login', (req, res) => {
   const user = db.get('users').find({ email, password }).value();
 
   if (user) {
+    res.cookie(AUTH_COOKIE_NAME, user.token, COOKIE_OPTIONS);
+
     res.json({
       successful: true,
       result: user.token,
@@ -56,81 +110,67 @@ app.post('/api/register', (req, res) => {
   });
 });
 
-app.get('/api/users/me', (req, res) => {
-  const token = req.headers.authorization;
-
-  if (!token) {
-    return res
-      .status(401)
-      .json({ successful: false, errors: ['No token provided'] });
-  }
-
-  const user = db.get('users').find({ token }).value();
-
-  if (user) {
-    res.json({
-      successful: true,
-      result: {
-        name: user.name,
-        email: user.email,
-        role: user.role,
-      },
-    });
-  } else {
-    res.status(401).json({ successful: false, errors: ['Invalid token'] });
-  }
+app.get('/api/users/me', requireAuth, (req, res) => {
+  res.json({
+    successful: true,
+    result: {
+      name: req.user.name,
+      email: req.user.email,
+      role: req.user.role,
+    },
+  });
 });
 
 app.delete('/api/logout', (req, res) => {
+  res.clearCookie(AUTH_COOKIE_NAME);
   res.json({ successful: true });
 });
 
 // --- Courses endpoints ---
+// Public reads, admin-only writes
 
 app.get('/api/courses/all', (req, res) => {
   const courses = db.get('courses').value();
   res.json({ successful: true, result: courses });
 });
 
-app.post('/api/courses/add', (req, res) => {
+app.post('/api/courses/add', requireAuth, requireAdmin, (req, res) => {
   const newCourse = {
     ...req.body,
     id: String(Date.now()),
     creationDate: new Date().toISOString(),
   };
-
   db.get('courses').push(newCourse).write();
   res.json({ successful: true, result: newCourse });
 });
 
-app.delete('/api/courses/:id', (req, res) => {
+app.delete('/api/courses/:id', requireAuth, requireAdmin, (req, res) => {
   db.get('courses').remove({ id: req.params.id }).write();
   res.json({ successful: true });
 });
 
-app.put('/api/courses/:id', (req, res) => {
+app.put('/api/courses/:id', requireAuth, requireAdmin, (req, res) => {
   const course = db
     .get('courses')
     .find({ id: req.params.id })
     .assign(req.body)
     .write();
-
   res.json({ successful: true, result: course });
 });
 
 // --- Authors endpoints ---
+// Public reads, admin-only writes
 
 app.get('/api/authors/all', (req, res) => {
   const authors = db.get('authors').value();
   res.json({ successful: true, result: authors });
 });
 
-app.post('/api/authors/add', (req, res) => {
+app.post('/api/authors/add', requireAuth, requireAdmin, (req, res) => {
   const newAuthor = {
     ...req.body,
     id: String(Date.now()),
   };
-
   db.get('authors').push(newAuthor).write();
   res.json({ successful: true, result: newAuthor });
 });


### PR DESCRIPTION
- Add cookie-parser middleware (consistent with backend-mock/server.js)
- Set HttpOnly cookie on POST /api/login — same pattern as local mock
- COOKIE_OPTIONS.secure set dynamically via NODE_ENV === 'production'
- Add requireAuth middleware — reads authToken cookie, looks up user in db
- Add requireAdmin middleware — checks role === 'admin', must follow requireAuth
- Apply requireAuth + requireAdmin to all write endpoints: POST /api/courses/add, DELETE /api/courses/:id, PUT /api/courses/:id, POST /api/authors/add
- GET /api/users/me now protected by requireAuth
- DELETE /api/logout clears the cookie
- Frontend unchanged — withCredentials: true already handles cookie sending