### PR TITLE
fix: add security headers to nginx configuration

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -4,25 +4,78 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # --- Security headers ---
+
+    # Prevent embedding in iframes on other domains (clickjacking)
+    add_header X-Frame-Options "DENY" always;
+
+    # Stop browser from guessing content type (MIME sniffing)
+    add_header X-Content-Type-Options "nosniff" always;
+
+    # Limit referrer info sent to external sites
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # Disable browser features not used by this app
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=()" always;
+
+    # Content Security Policy
+    # script-src 'self' — only scripts from this origin
+    # style-src 'self' 'unsafe-inline' — inline styles needed by React
+    # img-src 'self' data: — data URIs used by some icon libraries
+    # connect-src 'self' — API calls only to same origin (proxied through nginx)
+    # font-src 'self' — no external fonts
+    # object-src 'none' — block Flash and plugins
+    # base-uri 'self' — prevent base tag injection
+    # frame-ancestors 'none' — redundant with X-Frame-Options, defence in depth
+    add_header Content-Security-Policy "
+        default-src 'self';
+        script-src 'self';
+        style-src 'self' 'unsafe-inline';
+        img-src 'self' data:;
+        connect-src 'self';
+        font-src 'self';
+        object-src 'none';
+        base-uri 'self';
+        frame-ancestors 'none';
+    " always;
+
+    # --- Compression ---
+
     gzip on;
-    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_types text/plain text/css application/json application/javascript
+               text/xml application/xml application/xml+rss text/javascript;
+
+    # --- Static assets — aggressive caching ---
+    # Vite adds content hash to filenames so cache can be permanent
 
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+
+        # Security headers must be repeated inside location blocks
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     }
+
+    # --- API proxy ---
 
     location /api/ {
         rewrite ^/api/(.*)$ /$1 break;
-        
+
         proxy_pass http://backend:4000;
-        
+
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Don't cache API responses
+        add_header Cache-Control "no-store" always;
     }
+
+    # --- SPA fallback ---
 
     location / {
         try_files $uri $uri/ /index.html;

--- a/nginx.render.conf
+++ b/nginx.render.conf
@@ -4,15 +4,44 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # --- Security headers ---
+
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=()" always;
+    add_header Content-Security-Policy "
+        default-src 'self';
+        script-src 'self';
+        style-src 'self' 'unsafe-inline';
+        img-src 'self' data:;
+        connect-src 'self';
+        font-src 'self';
+        object-src 'none';
+        base-uri 'self';
+        frame-ancestors 'none';
+    " always;
+
+    # --- Compression ---
+
     gzip on;
     gzip_vary on;
     gzip_min_length 1024;
-    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml+rss application/json;
+    gzip_types text/plain text/css text/xml text/javascript
+               application/x-javascript application/xml+rss application/json;
+
+    # --- Static assets ---
 
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     }
+
+    # --- API proxy ---
 
     location /api/ {
         rewrite ^/api/(.*)$ /$1 break;
@@ -22,7 +51,11 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        add_header Cache-Control "no-store" always;
     }
+
+    # --- SPA fallback ---
 
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
Both nginx.conf and nginx.render.conf:
- X-Frame-Options: DENY — prevents clickjacking via iframe embedding
- X-Content-Type-Options: nosniff — prevents MIME type sniffing attacks
- Referrer-Policy: strict-origin-when-cross-origin — limits referrer leakage
- Permissions-Policy: disables geolocation, microphone, camera, payment APIs
- Content-Security-Policy: script-src 'self' — no inline scripts, no external script sources style-src 'self' unsafe-inline — inline styles required by React connect-src 'self' — API calls to same origin only (nginx proxy) object-src 'none' — blocks Flash and legacy plugins frame-ancestors 'none' — defence in depth with X-Frame-Options
- Repeat key headers in static assets location block (nginx inheritance caveat)
- Add Cache-Control: no-store on API proxy responses
- Note: HSTS omitted — HTTPS terminates at Railway load balancer, not nginx