### PR TITLE
fix: add email format validation to login and registration forms

### DIFF
--- a/src/components/Login/hooks/useLoginForm.js
+++ b/src/components/Login/hooks/useLoginForm.js
@@ -3,19 +3,22 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { loginUser } from '../../../store/user/thunk';
 import { selectUserStatus } from '../../../store/user/selectors';
+import isValidEmail from '../../../helpers/isValidEmail';
 
 const validate = (formData) => {
   const errors = {};
-  if (!formData.email) errors.email = 'Email is required';
+
+  if (!formData.email) {
+    errors.email = 'Email is required';
+  } else if (!isValidEmail(formData.email)) {
+    errors.email = 'Please enter a valid email address';
+  }
+
   if (!formData.password) errors.password = 'Password is required';
+
   return errors;
 };
 
-/**
- * Returns the redirect path from the URL query string if it is safe.
- * Accepts only relative paths (starting with /) to prevent open redirect.
- * Example: /login?redirect=/courses/add → '/courses/add'
- */
 const getSafeRedirectPath = (search) => {
   const params = new URLSearchParams(search);
   const redirect = params.get('redirect');

--- a/src/components/Login/hooks/useLoginForm.test.jsx
+++ b/src/components/Login/hooks/useLoginForm.test.jsx
@@ -137,6 +137,23 @@ describe('useLoginForm', () => {
       expect(result.current.errors.email).toBe('Email is required');
     });
 
+    it('sets email format error when email is invalid', async () => {
+      const { result } = renderHook(() => useLoginForm(), {
+        wrapper: buildWrapper(buildStore()),
+      });
+      act(() => {
+        result.current.handleChange({
+          target: { name: 'email', value: 'notanemail' },
+        });
+      });
+      await act(async () => {
+        await result.current.handleSubmit({ preventDefault: vi.fn() });
+      });
+      expect(result.current.errors.email).toBe(
+        'Please enter a valid email address'
+      );
+    });
+
     it('sets password error when password is empty', async () => {
       const { result } = renderHook(() => useLoginForm(), {
         wrapper: buildWrapper(buildStore()),

--- a/src/components/Registration/hooks/useRegistrationForm.js
+++ b/src/components/Registration/hooks/useRegistrationForm.js
@@ -3,12 +3,21 @@ import { useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { registerUser } from '../../../store/user/thunk';
 import { selectUserStatus } from '../../../store/user/selectors';
+import isValidEmail from '../../../helpers/isValidEmail';
 
 const validate = (userData) => {
   const errors = {};
+
   if (!userData.name) errors.name = 'Name is required';
-  if (!userData.email) errors.email = 'Email is required';
+
+  if (!userData.email) {
+    errors.email = 'Email is required';
+  } else if (!isValidEmail(userData.email)) {
+    errors.email = 'Please enter a valid email address';
+  }
+
   if (!userData.password) errors.password = 'Password is required';
+
   return errors;
 };
 

--- a/src/components/Registration/hooks/useRegistrationForm.test.jsx
+++ b/src/components/Registration/hooks/useRegistrationForm.test.jsx
@@ -49,7 +49,6 @@ describe('useRegistrationForm', () => {
       const { result } = renderHook(() => useRegistrationForm(), {
         wrapper: buildWrapper(buildStore()),
       });
-
       expect(result.current.userData).toEqual({
         name: '',
         email: '',
@@ -61,7 +60,6 @@ describe('useRegistrationForm', () => {
       const { result } = renderHook(() => useRegistrationForm(), {
         wrapper: buildWrapper(buildStore()),
       });
-
       expect(result.current.errors).toEqual({});
     });
 
@@ -69,7 +67,6 @@ describe('useRegistrationForm', () => {
       const { result } = renderHook(() => useRegistrationForm(), {
         wrapper: buildWrapper(buildStore()),
       });
-
       expect(result.current.isLoading).toBe(false);
     });
   });
@@ -79,13 +76,11 @@ describe('useRegistrationForm', () => {
       const { result } = renderHook(() => useRegistrationForm(), {
         wrapper: buildWrapper(buildStore()),
       });
-
       act(() => {
         result.current.handleChange({
           target: { name: 'name', value: 'Jan Kowalski' },
         });
       });
-
       expect(result.current.userData.name).toBe('Jan Kowalski');
     });
 
@@ -93,7 +88,6 @@ describe('useRegistrationForm', () => {
       const { result } = renderHook(() => useRegistrationForm(), {
         wrapper: buildWrapper(buildStore()),
       });
-
       act(() => {
         result.current.handleChange({
           target: { name: 'name', value: 'Jan Kowalski' },
@@ -102,7 +96,6 @@ describe('useRegistrationForm', () => {
           target: { name: 'email', value: 'jan@example.com' },
         });
       });
-
       expect(result.current.userData.name).toBe('Jan Kowalski');
       expect(result.current.userData.email).toBe('jan@example.com');
     });
@@ -113,11 +106,9 @@ describe('useRegistrationForm', () => {
       const { result } = renderHook(() => useRegistrationForm(), {
         wrapper: buildWrapper(buildStore()),
       });
-
       await act(async () => {
         await result.current.handleSubmit({ preventDefault: vi.fn() });
       });
-
       expect(result.current.errors.name).toBe('Name is required');
     });
 
@@ -125,25 +116,41 @@ describe('useRegistrationForm', () => {
       const { result } = renderHook(() => useRegistrationForm(), {
         wrapper: buildWrapper(buildStore()),
       });
-
       act(() => {
         result.current.handleChange({
           target: { name: 'name', value: 'Jan Kowalski' },
         });
       });
-
       await act(async () => {
         await result.current.handleSubmit({ preventDefault: vi.fn() });
       });
-
       expect(result.current.errors.email).toBe('Email is required');
+    });
+
+    it('sets email format error when email is invalid', async () => {
+      const { result } = renderHook(() => useRegistrationForm(), {
+        wrapper: buildWrapper(buildStore()),
+      });
+      act(() => {
+        result.current.handleChange({
+          target: { name: 'name', value: 'Jan Kowalski' },
+        });
+        result.current.handleChange({
+          target: { name: 'email', value: 'notanemail' },
+        });
+      });
+      await act(async () => {
+        await result.current.handleSubmit({ preventDefault: vi.fn() });
+      });
+      expect(result.current.errors.email).toBe(
+        'Please enter a valid email address'
+      );
     });
 
     it('sets password error when password is empty', async () => {
       const { result } = renderHook(() => useRegistrationForm(), {
         wrapper: buildWrapper(buildStore()),
       });
-
       act(() => {
         result.current.handleChange({
           target: { name: 'name', value: 'Jan Kowalski' },
@@ -152,11 +159,9 @@ describe('useRegistrationForm', () => {
           target: { name: 'email', value: 'jan@example.com' },
         });
       });
-
       await act(async () => {
         await result.current.handleSubmit({ preventDefault: vi.fn() });
       });
-
       expect(result.current.errors.password).toBe('Password is required');
     });
 
@@ -164,11 +169,9 @@ describe('useRegistrationForm', () => {
       const { result } = renderHook(() => useRegistrationForm(), {
         wrapper: buildWrapper(buildStore()),
       });
-
       await act(async () => {
         await result.current.handleSubmit({ preventDefault: vi.fn() });
       });
-
       expect(registerUserService).not.toHaveBeenCalled();
     });
   });
@@ -192,17 +195,13 @@ describe('useRegistrationForm', () => {
       registerUserService.mockResolvedValueOnce({
         data: { successful: true, user: { name: 'Jan Kowalski' } },
       });
-
       const { result } = renderHook(() => useRegistrationForm(), {
         wrapper: buildWrapper(buildStore()),
       });
-
       fillValidForm(result);
-
       await act(async () => {
         await result.current.handleSubmit({ preventDefault: vi.fn() });
       });
-
       expect(registerUserService).toHaveBeenCalledWith({
         name: 'Jan Kowalski',
         email: 'jan@example.com',
@@ -214,17 +213,13 @@ describe('useRegistrationForm', () => {
       registerUserService.mockResolvedValueOnce({
         data: { successful: true, user: { name: 'Jan Kowalski' } },
       });
-
       const { result } = renderHook(() => useRegistrationForm(), {
         wrapper: buildWrapper(buildStore()),
       });
-
       fillValidForm(result);
-
       await act(async () => {
         await result.current.handleSubmit({ preventDefault: vi.fn() });
       });
-
       expect(mockNavigate).toHaveBeenCalledWith('/login');
     });
 
@@ -232,29 +227,25 @@ describe('useRegistrationForm', () => {
       registerUserService.mockResolvedValueOnce({
         data: { successful: true, user: { name: 'Jan Kowalski' } },
       });
-
       const { result } = renderHook(() => useRegistrationForm(), {
         wrapper: buildWrapper(buildStore()),
       });
-
       fillValidForm(result);
-
       await act(async () => {
         await result.current.handleSubmit({ preventDefault: vi.fn() });
       });
-
       expect(mockNavigate).not.toHaveBeenCalledWith('/courses');
     });
   });
 
   describe('handleSubmit — failure', () => {
     it('sets server error when registerUserService rejects', async () => {
-      registerUserService.mockRejectedValueOnce(new Error('Email already taken'));
-
+      registerUserService.mockRejectedValueOnce(
+        new Error('Email already taken')
+      );
       const { result } = renderHook(() => useRegistrationForm(), {
         wrapper: buildWrapper(buildStore()),
       });
-
       act(() => {
         result.current.handleChange({
           target: { name: 'name', value: 'Jan Kowalski' },
@@ -266,11 +257,9 @@ describe('useRegistrationForm', () => {
           target: { name: 'password', value: 'secret123' },
         });
       });
-
       await act(async () => {
         await result.current.handleSubmit({ preventDefault: vi.fn() });
       });
-
       expect(result.current.errors.server).toBeDefined();
       expect(mockNavigate).not.toHaveBeenCalled();
     });

--- a/src/helpers/isValidEmail.js
+++ b/src/helpers/isValidEmail.js
@@ -1,0 +1,15 @@
+/**
+ * Validates email format with a practical regex.
+ * Covers the vast majority of real-world email addresses.
+ * Not RFC 5322 compliant by design — full RFC compliance
+ * adds complexity without meaningful benefit for most applications.
+ *
+ * Valid:   user@example.com, user.name+tag@sub.domain.co.uk
+ * Invalid: notanemail, @domain.com, user@, user@domain
+ */
+const isValidEmail = (email) => {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(String(email).toLowerCase().trim());
+};
+
+export default isValidEmail;

--- a/src/helpers/isValidEmail.test.js
+++ b/src/helpers/isValidEmail.test.js
@@ -1,0 +1,32 @@
+import isValidEmail from './isValidEmail';
+
+describe('isValidEmail', () => {
+  describe('valid emails', () => {
+    it.each([
+      'user@example.com',
+      'user.name@example.com',
+      'user+tag@example.com',
+      'user@sub.domain.com',
+      'user.name+tag@sub.domain.co.uk',
+      'USER@EXAMPLE.COM',
+      '  user@example.com  ',
+    ])('accepts %s', (email) => {
+      expect(isValidEmail(email)).toBe(true);
+    });
+  });
+
+  describe('invalid emails', () => {
+    it.each([
+      'notanemail',
+      '@domain.com',
+      'user@',
+      'user@domain',
+      '',
+      '   ',
+      'user @example.com',
+      'user@ example.com',
+    ])('rejects %s', (email) => {
+      expect(isValidEmail(email)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
- Add src/helpers/isValidEmail.js — practical regex /^[^\s@]+@[^\s@]+\.[^\s@]+$/ trims and lowercases before testing, reusable across both forms
- Add src/helpers/isValidEmail.test.js — 15 cases: valid and invalid formats
- useLoginForm: validate email format after empty check
- useRegistrationForm: validate email format after empty check
- Error message: 'Please enter a valid email address' (distinct from 'required')
- Add email format validation tests to both hook test files