### PR TITLE
fix: enforce MIN_PASSWORD_LENGTH in registration validation

### DIFF
--- a/src/components/Registration/hooks/useRegistrationForm.js
+++ b/src/components/Registration/hooks/useRegistrationForm.js
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { registerUser } from '../../../store/user/thunk';
 import { selectUserStatus } from '../../../store/user/selectors';
 import isValidEmail from '../../../helpers/isValidEmail';
+import { MIN_PASSWORD_LENGTH } from '../../../constants/validation';
 
 const validate = (userData) => {
   const errors = {};
@@ -16,7 +17,11 @@ const validate = (userData) => {
     errors.email = 'Please enter a valid email address';
   }
 
-  if (!userData.password) errors.password = 'Password is required';
+  if (!userData.password) {
+    errors.password = 'Password is required';
+  } else if (userData.password.length < MIN_PASSWORD_LENGTH) {
+    errors.password = `Password must be at least ${MIN_PASSWORD_LENGTH} characters`;
+  }
 
   return errors;
 };

--- a/src/components/Registration/hooks/useRegistrationForm.test.jsx
+++ b/src/components/Registration/hooks/useRegistrationForm.test.jsx
@@ -165,6 +165,29 @@ describe('useRegistrationForm', () => {
       expect(result.current.errors.password).toBe('Password is required');
     });
 
+    it('sets password length error when password is too short', async () => {
+      const { result } = renderHook(() => useRegistrationForm(), {
+        wrapper: buildWrapper(buildStore()),
+      });
+      act(() => {
+        result.current.handleChange({
+          target: { name: 'name', value: 'Jan Kowalski' },
+        });
+        result.current.handleChange({
+          target: { name: 'email', value: 'jan@example.com' },
+        });
+        result.current.handleChange({
+          target: { name: 'password', value: 'abc' },
+        });
+      });
+      await act(async () => {
+        await result.current.handleSubmit({ preventDefault: vi.fn() });
+      });
+      expect(result.current.errors.password).toBe(
+        'Password must be at least 6 characters'
+      );
+    });
+
     it('does not call registerUserService when validation fails', async () => {
       const { result } = renderHook(() => useRegistrationForm(), {
         wrapper: buildWrapper(buildStore()),


### PR DESCRIPTION
- Import MIN_PASSWORD_LENGTH (6) from constants/validation.js
- Add password length check in useRegistrationForm validate()
- Error message interpolates the constant: 'Password must be at least 6 characters'
- Validation applies only to registration — login intentionally unconstrained (wrong password rejected by backend regardless of length)
- Add test: 'sets password length error when password is too short'