### PR TITLE
fix: restrict API error logging to development mode only

### DIFF
--- a/src/services.js
+++ b/src/services.js
@@ -15,7 +15,16 @@ apiClient.interceptors.response.use(
       window.location.href = '/login';
     }
 
-    if (import.meta.env.MODE !== 'test') {
+    /**
+     * Log API errors in development only.
+     * In production, errors should be sent to a monitoring service
+     * (e.g. Sentry, Datadog) — not logged to the browser console
+     * where they are visible to anyone with DevTools open.
+     *
+     * Production example:
+     *   Sentry.captureException(error);
+     */
+    if (import.meta.env.MODE === 'development') {
       console.error(
         `[API Error] ${error.config?.method?.toUpperCase()} ${error.config?.url} — ${status ?? 'network error'}`,
         error.message


### PR DESCRIPTION
- Change MODE !== 'test' to MODE === 'development'
- Previous condition logged full method, URL and status to browser console in production — visible to anyone with DevTools open
- Development logging retained for debugging convenience
- Add comment explaining production approach: monitoring service (Sentry etc)
- Tests unaffected: MODE === 'test' was already excluded, still excluded