### PR TITLE
fix: correct vite dev proxy port from 5000 to 4000

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
     port: 3000,
     proxy: {
       '/api': {
-        target: 'http://localhost:5000',
+        target: 'http://localhost:4000',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ''),
       },


### PR DESCRIPTION
backend-mock listens on BACKEND_PORT || 4000
vite proxy was pointing to localhost:5000 — all API calls failed in local development immediately after cloning