### PR TITLE
refactor: use constants barrel file (index.js) across all imports

### DIFF
--- a/src/common/Input/Input.jsx
+++ b/src/common/Input/Input.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { HAS_ERROR_CLASS, ERROR_TEXT_CLASS } from '../../constants/ui';
+import { HAS_ERROR_CLASS, ERROR_TEXT_CLASS } from '../../constants';
 
 function Input({
   name,

--- a/src/components/CourseForm/hooks/useCourseForm.js
+++ b/src/components/CourseForm/hooks/useCourseForm.js
@@ -9,7 +9,7 @@ import {
   MIN_AUTHOR_NAME_LENGTH,
   MIN_COURSE_TITLE_LENGTH,
   MIN_COURSE_DESCRIPTION_LENGTH,
-} from '../../../constants/validation';
+} from '../../../constants';
 
 const validateCourseFields = ({ title, description, duration }) => {
   const errors = {};

--- a/src/components/CourseInfo/CourseInfo.jsx
+++ b/src/components/CourseInfo/CourseInfo.jsx
@@ -15,7 +15,7 @@ import { fetchCourses } from '../../store/courses/thunk';
 import {
   COURSE_INFO_LOADING_MESSAGE,
   COURSE_INFO_NOT_FOUND_MESSAGE,
-} from '../../constants/ui';
+} from '../../constants';
 import './CourseInfo.css';
 
 function CourseInfo() {
@@ -64,7 +64,8 @@ function CourseInfo() {
     );
   }
 
-  const authorNames = getAuthorNames(course.authors, authors) || 'No authors assigned';
+  const authorNames =
+    getAuthorNames(course.authors, authors) || 'No authors assigned';
 
   return (
     <div className="Course-all">

--- a/src/components/Courses/Courses.jsx
+++ b/src/components/Courses/Courses.jsx
@@ -14,7 +14,7 @@ import {
 } from '../../store/courses/selectors';
 import { selectAuthors, selectAuthorsStatus } from '../../store/authors/selectors';
 import { fetchCourses, deleteCourse } from '../../store/courses/thunk';
-import { ADD_NEW_COURSE_LABEL } from '../../constants/ui';
+import { ADD_NEW_COURSE_LABEL } from '../../constants';
 import './Courses.css';
 
 function Courses() {

--- a/src/components/Courses/components/SearchBar/SearchBar.jsx
+++ b/src/components/Courses/components/SearchBar/SearchBar.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { INPUT_PLACEHOLDER } from '../../../../constants/ui';
+import { INPUT_PLACEHOLDER } from '../../../../constants';
 import './SearchBar.css';
 
 const SearchBar = ({ value, onSearch }) => {

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -3,7 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { logoutUser } from '../../store/user/thunk';
 import { selectIsAuth, selectUserName } from '../../store/user/selectors';
-import { LOGIN_LABEL } from '../../constants/ui';
+import { LOGIN_LABEL } from '../../constants';
 import Logo from './components/Logo/Logo';
 import Button from '../../common/Button/Button';
 import './Header.css';

--- a/src/components/Registration/hooks/useRegistrationForm.js
+++ b/src/components/Registration/hooks/useRegistrationForm.js
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { registerUser } from '../../../store/user/thunk';
 import { selectUserStatus } from '../../../store/user/selectors';
 import isValidEmail from '../../../helpers/isValidEmail';
-import { MIN_PASSWORD_LENGTH } from '../../../constants/validation';
+import { MIN_PASSWORD_LENGTH } from '../../../constants';
 
 const validate = (userData) => {
   const errors = {};

--- a/src/helpers/getAuthorNames.js
+++ b/src/helpers/getAuthorNames.js
@@ -1,4 +1,4 @@
-import { MAX_AUTHORS_DISPLAY_LENGTH } from '../constants/validation';
+import { MAX_AUTHORS_DISPLAY_LENGTH } from '../constants';
 
 const getAuthorNames = (authorIds, authors, { truncate = false } = {}) => {
   if (!authorIds?.length || !authors?.length) return '';


### PR DESCRIPTION
- All imports now go through src/constants/index.js instead of directly to validation.js or ui.js
- constants/index.js already existed with export * from both files but was unused — now it serves its intended purpose
- 8 files updated: getAuthorNames, useCourseForm, useRegistrationForm, SearchBar, Courses, Header, CourseInfo, Input
- Shorter import paths, single entry point for constants module