### PR TITLE
fix: remove redundant token check in loginUser thunk

### DIFF
--- a/src/store/user/thunk.js
+++ b/src/store/user/thunk.js
@@ -52,7 +52,10 @@ export const loginUser = createAsyncThunk(
       const response = await loginUserService(credentials);
       const result = response.data;
 
-      if (result.successful && result.result) {
+      // Session is maintained via HttpOnly cookie set by the server.
+      // Token from result.result is intentionally not stored in Redux —
+      // it is only used server-side for cookie-based authentication.
+      if (result.successful) {
         return {
           name: result.user.name,
           email: result.user.email,


### PR DESCRIPTION
Previous condition: result.successful && result.result result.result contains the session token returned by the backend, but it was never stored or used — session relies on HttpOnly cookie.

The check implied the token was required for login to succeed, which was misleading. Simplified to result.successful only. Added comment explaining why the token is intentionally not stored.