### PR TITLE
fix: simplify API base URL — remove VITE_API_URL env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,6 @@ RUN npm ci --ignore-scripts --silent
 
 COPY . ./
 
-ARG VITE_API_URL=/api
-ENV VITE_API_URL=$VITE_API_URL
-
 RUN npm run build
 
 FROM node:18-alpine

--- a/Dockerfile.multi-container
+++ b/Dockerfile.multi-container
@@ -7,9 +7,6 @@ RUN npm ci --ignore-scripts --silent
 
 COPY . ./
 
-ARG VITE_API_URL=/api
-ENV VITE_API_URL=$VITE_API_URL
-
 RUN npm run build
 
 FROM nginx:alpine

--- a/src/config.js
+++ b/src/config.js
@@ -1,1 +1,1 @@
-export const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+export const API_BASE_URL = '/api';


### PR DESCRIPTION
/api works correctly in all environments:
- Development: Vite proxy rewrites /api/* → localhost:4000/*
- Railway: Express serves API under /api on same origin
- Docker/nginx: nginx proxies /api/* to backend container

VITE_API_URL was overriding the /api fallback causing requests to bypass Vite proxy and hit the wrong port directly. Removed ARG VITE_API_URL from Dockerfiles — no longer needed.