### PR TITLE
fix(ts): remove PayloadAction<unknown> from rejected cases in all red…

### DIFF
--- a/src/store/authors/reducer.ts
+++ b/src/store/authors/reducer.ts
@@ -23,16 +23,16 @@ const authorsSlice = createSlice({
         state.status = 'succeeded';
         state.authors = action.payload;
       })
-      .addCase(fetchAuthors.rejected, (state, action: PayloadAction<unknown>) => {
+      .addCase(fetchAuthors.rejected, (state, action) => {
         state.status = 'failed';
-        state.error = action.payload as string | null;
+        state.error = action.payload ?? null;
       })
       .addCase(createAuthor.fulfilled, (state, action: PayloadAction<Author>) => {
         state.authors.push(action.payload);
       })
-      .addCase(createAuthor.rejected, (state, action: PayloadAction<unknown>) => {
+      .addCase(createAuthor.rejected, (state, action) => {
         state.status = 'failed';
-        state.error = action.payload as string | null;
+        state.error = action.payload ?? null;
       });
   },
 });

--- a/src/store/courses/reducer.ts
+++ b/src/store/courses/reducer.ts
@@ -23,25 +23,25 @@ const coursesSlice = createSlice({
         state.status = 'succeeded';
         state.courses = action.payload;
       })
-      .addCase(fetchCourses.rejected, (state, action: PayloadAction<unknown>) => {
+      .addCase(fetchCourses.rejected, (state, action) => {
         state.status = 'failed';
-        state.error = action.payload as string | null;
+        state.error = action.payload ?? null;
       })
       .addCase(createCourse.fulfilled, (state, action: PayloadAction<Course>) => {
         state.courses.push(action.payload);
       })
-      .addCase(createCourse.rejected, (state, action: PayloadAction<unknown>) => {
+      .addCase(createCourse.rejected, (state, action) => {
         state.status = 'failed';
-        state.error = action.payload as string | null;
+        state.error = action.payload ?? null;
       })
-      .addCase(deleteCourse.fulfilled, (state, action: PayloadAction<string>) => {
+      .addCase(deleteCourse.fulfilled, (state, action) => {
         state.courses = state.courses.filter(
           (course) => course.id !== action.payload
         );
       })
-      .addCase(deleteCourse.rejected, (state, action: PayloadAction<unknown>) => {
+      .addCase(deleteCourse.rejected, (state, action) => {
         state.status = 'failed';
-        state.error = action.payload as string | null;
+        state.error = action.payload ?? null;
       })
       .addCase(updateCourse.fulfilled, (state, action: PayloadAction<Course>) => {
         const index = state.courses.findIndex(
@@ -51,9 +51,9 @@ const coursesSlice = createSlice({
           state.courses[index] = action.payload;
         }
       })
-      .addCase(updateCourse.rejected, (state, action: PayloadAction<unknown>) => {
+      .addCase(updateCourse.rejected, (state, action) => {
         state.status = 'failed';
-        state.error = action.payload as string | null;
+        state.error = action.payload ?? null;
       });
   },
 });

--- a/src/store/enrollments/reducer.ts
+++ b/src/store/enrollments/reducer.ts
@@ -23,9 +23,9 @@ const enrollmentsSlice = createSlice({
         state.status = 'succeeded';
         state.enrollments = action.payload;
       })
-      .addCase(fetchEnrollments.rejected, (state, action: PayloadAction<unknown>) => {
+      .addCase(fetchEnrollments.rejected, (state, action) => {
         state.status = 'failed';
-        state.error = action.payload as string | null;
+        state.error = action.payload ?? null;
       })
       .addCase(enrollCourse.fulfilled, (state, action: PayloadAction<Enrollment>) => {
         state.enrollments.push(action.payload);

--- a/src/store/user/reducer.ts
+++ b/src/store/user/reducer.ts
@@ -28,13 +28,13 @@ const userSlice = createSlice({
         state.role = action.payload.role;
         state.isAuth = true;
       })
-      .addCase(fetchUser.rejected, (state) => {
+      .addCase(fetchUser.rejected, (state, action) => {
         state.status = 'idle';
         state.isAuth = false;
         state.name = null;
         state.email = null;
         state.role = null;
-        state.error = null;
+        state.error = action.payload ?? null;
       })
       .addCase(loginUser.pending, (state) => {
         state.status = 'loading';
@@ -48,9 +48,9 @@ const userSlice = createSlice({
         state.isAuth = true;
         state.error = null;
       })
-      .addCase(loginUser.rejected, (state, action: PayloadAction<unknown>) => {
+      .addCase(loginUser.rejected, (state, action) => {
         state.status = 'failed';
-        state.error = action.payload as string | null;
+        state.error = action.payload ?? null;
       })
       .addCase(logoutUser.fulfilled, (state) => {
         state.status = 'idle';


### PR DESCRIPTION
…ucers

Now that thunks are fully typed with createAsyncThunk generics ({ rejectValue: string }), RTK infers the rejected payload type automatically as string | undefined.

Changes per reducer:
- Remove explicit PayloadAction<unknown> type annotation on rejected cases
- Remove 'as string | null' type assertion
- Replace with action.payload ?? null (nullish coalescing) payload is string | undefined — ?? converts undefined to null which matches the slice state type error: string | null

Backlog item resolved: PayloadAction<unknown> was a temporary workaround during iterative migration (reducers migrated before thunks).