### PR TITLE
feat(ts): enable strict mode in tsconfig

### DIFF
--- a/src/components/CourseForm/hooks/useCourseForm.ts
+++ b/src/components/CourseForm/hooks/useCourseForm.ts
@@ -136,19 +136,39 @@ const useCourseForm = (): UseCourseFormReturn => {
       return;
     }
 
-    const courseData = {
-      ...(isEditMode && courseId ? { id: courseId } : {}),
-      title: String(fields.title),
-      description: String(fields.description),
-      duration: Number(fields.duration),
-      authors: courseAuthors,
-    };
+    setIsSaving(true);
+
+    let result;
+
+    if (isEditMode && courseId) {
+      const courseToUpdate = courses.find((course) => course.id === courseId);
+
+      const creationDate = courseToUpdate?.creationDate ?? new Date().toISOString();
+
+      result = await dispatch(
+        updateCourse({
+          id: courseId,
+          title: String(fields.title),
+          description: String(fields.description),
+          duration: Number(fields.duration),
+          authors: courseAuthors,
+          creationDate,
+        })
+      );
+    } else {
+      result = await dispatch(
+        createCourse({
+          title: String(fields.title),
+          description: String(fields.description),
+          duration: Number(fields.duration),
+          authors: courseAuthors,
+        })
+      );
+    }
+
+    setIsSaving(false);
 
     const action = isEditMode ? updateCourse : createCourse;
-
-    setIsSaving(true);
-    const result = await dispatch(action(courseData));
-    setIsSaving(false);
 
     if (action.fulfilled.match(result)) {
       navigate('/courses');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,9 +16,7 @@
     "allowJs": true,
     "checkJs": false,
 
-    "strict": false,
-    "noImplicitAny": false,
-    "strictNullChecks": false,
+    "strict": true,
 
     "types": ["vitest/globals", "vite/client"]
   },


### PR DESCRIPTION
- Set strict: true — enables strictNullChecks, noImplicitAny, strictFunctionTypes, strictBindCallApply, strictPropertyInitialization
- Remove explicit noImplicitAny: false and strictNullChecks: false which were temporary workarounds during iterative TS migration

Bug found and fixed by strict mode:
- useCourseForm handleSubmit: courseData was missing creationDate when dispatching updateCourse — TypeScript correctly flagged this as Course interface requires creationDate field
- Fix: split create/update into separate dispatch paths updateCourse now explicitly passes creationDate from original course ?? fallback to new Date().toISOString() if course not found in store