### PR TITLE
fix: add error handling to handleEnroll in CourseCard

### DIFF
--- a/src/components/Courses/components/CourseCard/CourseCard.css
+++ b/src/components/Courses/components/CourseCard/CourseCard.css
@@ -98,3 +98,10 @@
   opacity: 0.7;
   cursor: not-allowed;
 }
+
+.enroll-error {
+  color: #dc3545;
+  font-size: 12px;
+  margin: 4px 0 0 0;
+  text-align: right;
+}

--- a/src/components/Courses/components/CourseCard/CourseCard.tsx
+++ b/src/components/Courses/components/CourseCard/CourseCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Button from '../../../../common/Button/Button';
 import formatCreationDate from '../../../../helpers/formatCreationDate';
@@ -27,11 +28,18 @@ function CourseCard({
   onUpdate,
 }: CourseCardProps) {
   const dispatch = useDispatch<AppDispatch>();
-
   const isEnrolled = useSelector(selectIsEnrolled(course.id));
+  const [enrollError, setEnrollError] = useState<string | null>(null);
 
-  const handleEnroll = (): void => {
-    dispatch(enrollCourse(course.id));
+  const handleEnroll = async (): Promise<void> => {
+    setEnrollError(null);
+    const result = await dispatch(enrollCourse(course.id));
+
+    if (enrollCourse.rejected.match(result)) {
+      setEnrollError(
+        result.payload || 'Failed to enroll. Please try again.'
+      );
+    }
   };
 
   return (
@@ -66,12 +74,17 @@ function CourseCard({
               />
             </>
           ) : (
-            <Button
-              label={isEnrolled ? 'Enrolled ✓' : 'Enroll'}
-              className={`Course-button${isEnrolled ? ' Course-button--enrolled' : ''}`}
-              onClick={handleEnroll}
-              disabled={isEnrolled}
-            />
+            <>
+              <Button
+                label={isEnrolled ? 'Enrolled ✓' : 'Enroll'}
+                className={`Course-button${isEnrolled ? ' Course-button--enrolled' : ''}`}
+                onClick={handleEnroll}
+                disabled={isEnrolled}
+              />
+              {enrollError && (
+                <p className="enroll-error">{enrollError}</p>
+              )}
+            </>
           )}
         </div>
       </div>


### PR DESCRIPTION
Previous implementation dispatched enrollCourse without awaiting the result — enrollment failures were silently ignored and the user received no feedback.

Changes:
- handleEnroll is now async and awaits dispatch result
- enrollCourse.rejected.match() checks if the action failed
- Local enrollError state displays error message below Enroll button
- setEnrollError(null) clears previous error on each attempt
- Error message styled in red, right-aligned with course details