### PR TITLE
fix: unify button styles and add danger variant

### DIFF
--- a/src/common/Button/Button.css
+++ b/src/common/Button/Button.css
@@ -1,30 +1,50 @@
 .Button {
+  display: inline-block;
   padding: 10px 20px;
   font-size: 14px;
   font-weight: 500;
-  
-  color: #ffffff;
-  background-color: #007bff;
-  
+  text-align: center;
+  text-decoration: none;
+
   border: none;
   border-radius: 4px;
-  
+
   cursor: pointer;
   transition: all 0.2s ease;
   white-space: nowrap;
-  
+
   font-family: inherit;
   line-height: 1;
 }
 
-.Button:hover {
+.Button--primary {
+  color: #ffffff;
+  background-color: #007bff;
+}
+
+.Button--primary:hover {
   background-color: #0056b3;
   box-shadow: 0 2px 8px rgba(0, 86, 179, 0.2);
 }
 
-.Button:active {
+.Button--primary:active {
   transform: scale(0.98);
   box-shadow: 0 1px 4px rgba(0, 86, 179, 0.2);
+}
+
+.Button--danger {
+  color: #ffffff;
+  background-color: #dc3545;
+}
+
+.Button--danger:hover {
+  background-color: #b02a37;
+  box-shadow: 0 2px 8px rgba(176, 42, 55, 0.2);
+}
+
+.Button--danger:active {
+  transform: scale(0.98);
+  box-shadow: 0 1px 4px rgba(176, 42, 55, 0.2);
 }
 
 .Button:disabled {
@@ -46,21 +66,4 @@
 
 .Button:focus:not(:focus-visible) {
   outline: none;
-}
-
-.Button--link {
-  background: transparent;
-  color: #007bff;
-  padding: 0;
-  font-size: 14px;
-  font-weight: 500;
-  border: none;
-  border-radius: 0;
-  box-shadow: none;
-}
-
-.Button--link:hover {
-  text-decoration: underline;
-  background: transparent;
-  box-shadow: none;
 }

--- a/src/common/Button/Button.tsx
+++ b/src/common/Button/Button.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import './Button.css';
 
 interface ButtonProps {
@@ -6,6 +7,8 @@ interface ButtonProps {
   className?: string;
   type?: 'button' | 'submit' | 'reset';
   disabled?: boolean;
+  to?: string;
+  variant?: 'primary' | 'danger';
 }
 
 function Button({
@@ -14,11 +17,23 @@ function Button({
   label,
   type = 'button',
   disabled = false,
+  to,
+  variant = 'primary',
 }: ButtonProps) {
+  const classes = `Button Button--${variant} ${className}`.trim();
+
+  if (to) {
+    return (
+      <Link to={to} className={classes}>
+        {label}
+      </Link>
+    );
+  }
+
   return (
     <button
       type={type}
-      className={`Button ${className}`}
+      className={classes}
       onClick={onClick}
       disabled={disabled}
     >

--- a/src/components/CourseInfo/CourseInfo.tsx
+++ b/src/components/CourseInfo/CourseInfo.tsx
@@ -1,4 +1,4 @@
-import { useParams, Link } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import formatCreationDate from '../../helpers/formatCreationDate';
 import getCourseDuration from '../../helpers/getCourseDuration';
@@ -61,9 +61,7 @@ function CourseInfo() {
     return (
       <div className="Course-all">
         <p>{COURSE_INFO_NOT_FOUND_MESSAGE}</p>
-        <Link to="/courses" className="back-button">
-          Back to Courses
-        </Link>
+          <Button label="Back to Courses" to="/courses" />
       </div>
     );
   }
@@ -98,9 +96,7 @@ function CourseInfo() {
           />
         )}
       </div>
-      <Link to="/courses" className="back-button">
-        Back to Courses
-      </Link>
+        <Button label="Back to Courses" to="/courses" />
     </div>
   );
 }

--- a/src/components/Courses/components/CourseCard/CourseCard.css
+++ b/src/components/Courses/components/CourseCard/CourseCard.css
@@ -63,20 +63,7 @@
 }
 
 .Course-button {
-  padding: 10px 20px;
-  background-color: #007bff;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 14px;
-  font-weight: 500;
-  transition: background-color 0.2s;
   white-space: nowrap;
-}
-
-.Course-button:hover {
-  background-color: #0056b3;
 }
 
 @media (max-width: 768px) {

--- a/src/components/Courses/components/CourseCard/CourseCard.tsx
+++ b/src/components/Courses/components/CourseCard/CourseCard.tsx
@@ -64,6 +64,7 @@ function CourseCard({
             <>
               <Button
                 label="DELETE"
+                variant="danger"
                 className="Course-button"
                 onClick={() => onDelete(course.id)}
               />

--- a/src/components/Enrolled/Enrolled.tsx
+++ b/src/components/Enrolled/Enrolled.tsx
@@ -1,8 +1,8 @@
 import { useSelector } from 'react-redux';
-import { Link } from 'react-router-dom';
 import { selectEnrollments, selectEnrollmentsStatus, selectEnrollmentsError } from '../../store/enrollments/selectors';
 import ErrorMessage from '../../common/ErrorMessage/ErrorMessage';
 import './Enrolled.css';
+import Button from '../../common/Button/Button';
 
 function Enrolled() {
   const enrollments = useSelector(selectEnrollments);
@@ -32,9 +32,7 @@ function Enrolled() {
     <div className="Enrolled">
       <div className="Enrolled-header">
         <h2>Enrolled Students</h2>
-        <Link to="/courses" className="back-button">
-          Back to Courses
-        </Link>
+        <Button label="Back to Courses" to="/courses" />
       </div>
       {enrollments.length === 0 ? (
         <p className="Enrolled-empty">No students enrolled yet.</p>

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom';
 import Input from '../../common/Input/Input';
 import Button from '../../common/Button/Button';
 import useLoginForm from './hooks/useLoginForm';
@@ -34,7 +33,7 @@ function Login() {
         label={isLoading ? 'Logging in...' : 'Login'}
         disabled={isLoading}
       />
-      <Link to="/registration">{"Don't have an account? Register here"}</Link>
+      <Button label="Click to register" to="/registration" />
     </form>
   );
 }

--- a/src/components/Registration/Registration.tsx
+++ b/src/components/Registration/Registration.tsx
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom';
 import Button from '../../common/Button/Button';
 import Input from '../../common/Input/Input';
 import useRegistrationForm from './hooks/useRegistrationForm';
@@ -38,9 +37,7 @@ function Registration() {
         label={isLoading ? 'Registering...' : 'Register'}
         disabled={isLoading}
       />
-      <Link to="/login">
-        If you have an account you may <strong>Login</strong>
-      </Link>
+      <Button label="Click to login" to="/login" />
     </form>
   );
 }


### PR DESCRIPTION
Button component:
- Add 'to' prop — renders as <Link> instead of <button> preserves HTML semantics (navigation = anchor, action = button) same visual appearance regardless of underlying element
- Add 'variant' prop ('primary' | 'danger', default: 'primary') danger variant renders red background for destructive actions
- Add display: inline-block and text-decoration: none ensures Link-rendered buttons look identical to button-rendered ones

Component updates:
- CourseInfo: Back to Courses rendered as Button with to prop
- Login: Register link rendered as Button with to prop
- Registration: Login link rendered as Button with to prop
- Enrolled: Back to Courses rendered as Button with to prop
- CourseCard: DELETE button uses variant='danger' — red background