### PR TITLE
feat: move Enrolled Students button to Header

### DIFF
--- a/src/components/Courses/Courses.css
+++ b/src/components/Courses/Courses.css
@@ -9,24 +9,6 @@
 
 .Courses-toolbar {
   display: flex;
-  flex-direction: row;
   align-items: center;
-  justify-content: space-between;
   width: 100%;
-}
-
-.ButtonEnrolled {
-  white-space: nowrap;
-}
-
-@media (max-width: 768px) {
-  .Courses-toolbar {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 10px;
-  }
-
-  .ButtonEnrolled {
-    width: 100%;
-  }
 }

--- a/src/components/Courses/Courses.tsx
+++ b/src/components/Courses/Courses.tsx
@@ -78,19 +78,10 @@ function Courses() {
     );
   }
 
-  return (
+    return (
     <div className="Courses">
       <div className="Courses-toolbar">
         <SearchBar value={query} onSearch={setQuery} />
-        {isAdmin && (
-          <div className="Courses-toolbar-actions">
-            <Button
-              label="Enrolled Students"
-              className="ButtonEnrolled"
-              onClick={() => navigate('/enrolled')}
-            />
-          </div>
-        )}
       </div>
       {deleteError && (
         <ErrorMessage

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -15,16 +15,16 @@
   flex-shrink: 0;
 }
 
-.Header > div:last-child {
-  display: flex;
-  align-items: center;
-  gap: 20px;
-}
-
 .Hello {
   font-size: 16px;
   color: #333;
   font-weight: 500;
+}
+
+.Header-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
 }
 
 .ButtonHeader {
@@ -37,10 +37,23 @@
   font-size: 14px;
   font-weight: 500;
   transition: background-color 0.2s;
+  white-space: nowrap;
 }
 
 .ButtonHeader:hover {
   background-color: #0056b3;
+}
+
+.ButtonHeader--secondary {
+  background-color: #007bff;
+  color: white;
+  border: none;
+  font-size: 14px;
+}
+
+.ButtonHeader--secondary:hover {
+  background-color: #0056b3;
+  color: white;
 }
 
 @media (max-width: 768px) {
@@ -54,8 +67,4 @@
     font-size: 14px;
   }
 
-  .ButtonHeader {
-    padding: 8px 16px;
-    font-size: 13px;
-  }
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { logoutUser } from '../../store/user/thunk';
-import { selectIsAuth, selectUserName } from '../../store/user/selectors';
+import { selectIsAuth, selectIsAdmin, selectUserName } from '../../store/user/selectors';
 import { LOGIN_LABEL } from '../../constants';
 import Logo from './components/Logo/Logo';
 import Button from '../../common/Button/Button';
@@ -13,6 +13,7 @@ function Header() {
   const location = useLocation();
   const dispatch = useDispatch<AppDispatch>();
   const isAuth = useSelector(selectIsAuth);
+  const isAdmin = useSelector(selectIsAdmin);
   const userName = useSelector(selectUserName);
 
   const handleLogout = async (): Promise<void> => {
@@ -31,11 +32,20 @@ function Header() {
         <>
           {userName && <div className="Hello">Hello, {userName}</div>}
           {isAuth ? (
-            <Button
-              label="Logout"
-              className="ButtonHeader"
-              onClick={handleLogout}
-            />
+            <div className="Header-actions">
+              <Button
+                label="Logout"
+                className="ButtonHeader"
+                onClick={handleLogout}
+              />
+              {isAdmin && (
+                <Button
+                  label="Enrolled Students"
+                  className="ButtonHeader ButtonHeader--secondary"
+                  to="/enrolled"
+                />
+              )}
+            </div>
           ) : (
             <Button
               label={LOGIN_LABEL}


### PR DESCRIPTION
- Header: add Header-actions wrapper — stacks Logout and Enrolled Students vertically, aligned to right edge
- Header: Enrolled Students visible only for admin (selectIsAdmin)
- Header: ButtonHeader--secondary style — smaller outlined button visually subordinate to Logout button
- Courses: remove Enrolled Students button and Courses-toolbar-actions toolbar now contains only SearchBar
- Courses.css: remove unused Courses-toolbar-actions styles