### PR TITLE
refactor(css): introduce CSS custom properties across all stylesheets

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -7,19 +7,18 @@
 .App {
   width: 100%;
   min-height: 100vh;
-  background-color: #f5f5f5;
 }
 
 .Content {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 40px 20px;
+  padding: var(--spacing-xl) var(--spacing-lg);
   width: 100%;
   min-height: calc(100vh - 80px);
 }
 
 @media (max-width: 768px) {
   .Content {
-    padding: 20px 10px;
+    padding: var(--spacing-lg) 10px;
   }
 }

--- a/src/common/Button/Button.css
+++ b/src/common/Button/Button.css
@@ -1,13 +1,16 @@
 .Button {
-  display: inline-block;
-  padding: 10px 20px;
-  font-size: 14px;
+  width: var(--button-width);
+  padding: 10px var(--spacing-lg);
+  font-size: var(--font-size-base);
   font-weight: 500;
   text-align: center;
   text-decoration: none;
 
+  color: var(--color-surface);
+  background-color: var(--color-primary);
+
   border: none;
-  border-radius: 4px;
+  border-radius: var(--border-radius);
 
   cursor: pointer;
   transition: all 0.2s ease;
@@ -15,55 +18,4 @@
 
   font-family: inherit;
   line-height: 1;
-}
-
-.Button--primary {
-  color: #ffffff;
-  background-color: #007bff;
-}
-
-.Button--primary:hover {
-  background-color: #0056b3;
-  box-shadow: 0 2px 8px rgba(0, 86, 179, 0.2);
-}
-
-.Button--primary:active {
-  transform: scale(0.98);
-  box-shadow: 0 1px 4px rgba(0, 86, 179, 0.2);
-}
-
-.Button--danger {
-  color: #ffffff;
-  background-color: #dc3545;
-}
-
-.Button--danger:hover {
-  background-color: #b02a37;
-  box-shadow: 0 2px 8px rgba(176, 42, 55, 0.2);
-}
-
-.Button--danger:active {
-  transform: scale(0.98);
-  box-shadow: 0 1px 4px rgba(176, 42, 55, 0.2);
-}
-
-.Button:disabled {
-  background-color: #cccccc;
-  cursor: not-allowed;
-  opacity: 0.6;
-  box-shadow: none;
-}
-
-.Button:disabled:hover {
-  background-color: #cccccc;
-  transform: none;
-}
-
-.Button:focus {
-  outline: 2px solid #0056b3;
-  outline-offset: 2px;
-}
-
-.Button:focus:not(:focus-visible) {
-  outline: none;
 }

--- a/src/common/Button/Button.tsx
+++ b/src/common/Button/Button.tsx
@@ -8,7 +8,7 @@ interface ButtonProps {
   type?: 'button' | 'submit' | 'reset';
   disabled?: boolean;
   to?: string;
-  variant?: 'primary' | 'danger';
+  variant?: 'primary' | 'danger' | 'link';
 }
 
 function Button({
@@ -24,7 +24,7 @@ function Button({
 
   if (to) {
     return (
-      <Link to={to} className={classes}>
+      <Link to={to} className={classes} style={{ display: 'inline-block', textDecoration: 'none' }}>
         {label}
       </Link>
     );

--- a/src/common/ErrorMessage/ErrorMessage.css
+++ b/src/common/ErrorMessage/ErrorMessage.css
@@ -8,7 +8,7 @@
 }
 
 .error-container__message {
-  color: #c0392b;
-  font-size: 1rem;
+  color: var(--color-error);
+  font-size: var(--font-size-md);
   margin: 0;
 }

--- a/src/components/CourseForm/CourseForm.css
+++ b/src/components/CourseForm/CourseForm.css
@@ -10,25 +10,25 @@
 .CreateCourse label {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  font-size: 14px;
+  gap: var(--spacing-xs);
+  font-size: var(--font-size-base);
   font-weight: 500;
-  color: #333;
+  color: var(--color-text);
 }
 
 .CreateCourse input,
 .CreateCourse textarea {
-  padding: 8px 12px;
-  font-size: 14px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  padding: var(--spacing-sm) 12px;
+  font-size: var(--font-size-base);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
   outline: none;
   transition: border-color 0.2s;
 }
 
 .CreateCourse input:focus,
 .CreateCourse textarea:focus {
-  border-color: #555;
+  border-color: var(--color-text-secondary);
 }
 
 .CreateCourse textarea {
@@ -41,8 +41,8 @@
 }
 
 .CreateCourse .error-message {
-  font-size: 12px;
-  color: #c0392b;
+  font-size: var(--font-size-sm);
+  color: var(--color-error);
   min-height: 18px;
   margin: 0;
 }
@@ -50,12 +50,12 @@
 .CreateCourse .authors-section {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--spacing-sm);
 }
 
 .CreateCourse .authors-section__title {
-  font-size: 14px;
+  font-size: var(--font-size-base);
   font-weight: 500;
-  color: #333;
+  color: var(--color-text);
   margin: 0;
 }

--- a/src/components/CourseInfo/CourseInfo.css
+++ b/src/components/CourseInfo/CourseInfo.css
@@ -1,16 +1,17 @@
 .Course-all {
-  width: 1000px;
-  box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.1);
-  border-radius: 8px;
+  width: 100%;
+  max-width: 1000px;
+  box-shadow: var(--shadow-sm);
+  border-radius: var(--border-radius-lg);
   overflow: hidden;
-  background: white;
-  padding: 20px;
+  background: var(--color-surface);
+  padding: var(--spacing-lg);
 }
 
 .Course-info {
   display: flex;
   flex-direction: column;
-  padding-right: 20px;
+  padding-right: var(--spacing-lg);
   flex: 0.7;
 }
 
@@ -23,24 +24,10 @@
   flex-direction: column;
 }
 
-.Button {
-  margin-top: 24px;
-  width: 190px;
-  height: 30px;
-  color: #f7f7f7;
-  background: #007bff;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
 .course-detail-panel {
   display: flex;
   flex-direction: column;
-  gap: 20px;
-}
-
-.enroll-button {
-  margin-top: 1rem;
+  gap: var(--spacing-lg);
 }
 
 .enroll-button--enrolled {

--- a/src/components/Courses/Courses.css
+++ b/src/components/Courses/Courses.css
@@ -1,14 +1,28 @@
 .Courses {
   width: 100%;
   min-height: 100vh;
-  padding: 20px 0;
+  padding: var(--spacing-lg) 0;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: var(--spacing-lg);
 }
 
 .Courses-toolbar {
   display: flex;
+  flex-direction: row;
   align-items: center;
   width: 100%;
+}
+
+@media (max-width: 768px) {
+  .Courses-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+}
+
+.ButtonAdd {
+  width: var(--button-width);
+  align-self: center;
 }

--- a/src/components/Courses/components/CourseCard/CourseCard.css
+++ b/src/components/Courses/components/CourseCard/CourseCard.css
@@ -1,25 +1,23 @@
 .Course-card {
   width: 100%;
-  background: #ffffff;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  padding: 20px;
+  background: var(--color-surface);
+  border-radius: var(--border-radius-lg);
+  box-shadow: var(--shadow-sm);
+  padding: var(--spacing-lg);
   transition: box-shadow 0.2s;
   min-height: 200px;
-  height: auto;
 }
 
 .Course-card:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-md);
 }
 
 .Course-rect {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 20px;
+  gap: var(--spacing-lg);
   width: 100%;
-  height: auto;
 }
 
 .Course-info {
@@ -28,15 +26,15 @@
 }
 
 .Course-info h3 {
-  font-size: 20px;
+  font-size: var(--font-size-lg);
   font-weight: 600;
-  color: #333;
+  color: var(--color-text);
   margin-bottom: 10px;
 }
 
 .Course-info p {
-  font-size: 14px;
-  color: #666;
+  font-size: var(--font-size-base);
+  color: var(--color-text-muted);
   line-height: 1.5;
   word-wrap: break-word;
 }
@@ -52,9 +50,9 @@
 .Course-details-info {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  font-size: 14px;
-  color: #555;
+  gap: var(--spacing-sm);
+  font-size: var(--font-size-base);
+  color: var(--color-text-secondary);
   text-align: right;
 }
 
@@ -63,7 +61,20 @@
 }
 
 .Course-button {
+  width: var(--button-width);
   white-space: nowrap;
+}
+
+.Course-button--enrolled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.enroll-error {
+  color: var(--color-danger);
+  font-size: var(--font-size-sm);
+  margin: var(--spacing-xs) 0 0 0;
+  text-align: right;
 }
 
 @media (max-width: 768px) {
@@ -79,16 +90,4 @@
   .Course-details-info {
     text-align: left;
   }
-}
-
-.Course-button--enrolled {
-  opacity: 0.7;
-  cursor: not-allowed;
-}
-
-.enroll-error {
-  color: #dc3545;
-  font-size: 12px;
-  margin: 4px 0 0 0;
-  text-align: right;
 }

--- a/src/components/Courses/components/SearchBar/SearchBar.css
+++ b/src/components/Courses/components/SearchBar/SearchBar.css
@@ -1,23 +1,22 @@
+.Search-bar {
+  display: flex;
+  align-items: center;
+}
+
 .Search-bar input {
   flex-grow: 1;
-  border: none;
   padding: 10px;
-  font-size: 100%;
-  border-radius: 4px 0 0 4px;
+  font-size: var(--font-size-base);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.Search-bar input:focus {
+  border-color: var(--color-text-secondary);
 }
 
 .Search-bar input::placeholder {
-  font-size: 115%;
-}
-
-.Search-bar button {
-  border-radius: 0 4px 4px 0;
-}
-
-.ButtonBar {
-  width: 90px;
-  height: 34px;
-  color: #f7f7f7;
-  background: #007bff;
-  border-radius: 4px;
+  color: var(--color-text-muted);
 }

--- a/src/components/Enrolled/Enrolled.css
+++ b/src/components/Enrolled/Enrolled.css
@@ -1,7 +1,7 @@
 .Enrolled {
   max-width: 900px;
   margin: 2rem auto;
-  padding: 0 1rem;
+  padding: 0 var(--spacing-md);
 }
 
 .Enrolled-header {
@@ -17,7 +17,7 @@
 }
 
 .Enrolled-empty {
-  color: var(--color-text-secondary, #666);
+  color: var(--color-text-muted);
   text-align: center;
   padding: 2rem 0;
 }
@@ -25,20 +25,20 @@
 .Enrolled-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 14px;
+  font-size: var(--font-size-base);
 }
 
 .Enrolled-table th {
   text-align: left;
-  padding: 10px 16px;
-  border-bottom: 2px solid #e0e0e0;
+  padding: 10px var(--spacing-md);
+  border-bottom: 2px solid var(--color-border-light);
   font-weight: 600;
-  color: #333;
+  color: var(--color-text);
 }
 
 .Enrolled-table td {
-  padding: 10px 16px;
-  border-bottom: 1px solid #f0f0f0;
+  padding: 10px var(--spacing-md);
+  border-bottom: 1px solid var(--color-border-light);
   color: #444;
 }
 

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -3,68 +3,90 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 20px 40px;
-  background-color: #ffffff;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  padding: var(--spacing-lg) var(--spacing-xl);
+  background-color: var(--color-surface);
+  box-shadow: var(--shadow-sm);
   position: sticky;
   top: 0;
   z-index: 1000;
 }
 
-.Header .Logo {
+.Header-left {
   flex-shrink: 0;
 }
 
 .Hello {
-  font-size: 16px;
-  color: #333;
+  flex: 1;
+  text-align: center;
+  font-size: var(--font-size-md);
+  color: var(--color-text);
   font-weight: 500;
+}
+
+.Header-right {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-lg);
 }
 
 .Header-actions {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+  gap: 10px;
 }
 
 .ButtonHeader {
-  padding: 10px 20px;
-  background-color: #007bff;
-  color: white;
+  min-width: var(--button-width);
+  padding: 10px var(--spacing-lg);
+  background-color: var(--color-primary);
+  color: var(--color-surface);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--border-radius);
   cursor: pointer;
-  font-size: 14px;
+  font-size: var(--font-size-base);
   font-weight: 500;
   transition: background-color 0.2s;
   white-space: nowrap;
+  text-decoration: none;
+  display: inline-block;
+  text-align: center;
 }
 
 .ButtonHeader:hover {
-  background-color: #0056b3;
+  background-color: var(--color-primary-dark);
 }
 
 .ButtonHeader--secondary {
-  background-color: #007bff;
-  color: white;
+  background-color: var(--color-primary);
+  color: var(--color-surface);
   border: none;
-  font-size: 14px;
+  padding: 10px var(--spacing-lg);
+  font-size: var(--font-size-base);
+  min-width: var(--button-width);
+  text-align: center;
 }
 
 .ButtonHeader--secondary:hover {
-  background-color: #0056b3;
-  color: white;
+  background-color: var(--color-primary-dark);
 }
 
 @media (max-width: 768px) {
   .Header {
-    padding: 15px 20px;
+    padding: 15px var(--spacing-lg);
     flex-wrap: wrap;
     gap: 15px;
   }
 
   .Hello {
-    font-size: 14px;
+    font-size: var(--font-size-base);
+    text-align: left;
+    flex: unset;
   }
 
+  .ButtonHeader {
+    padding: var(--spacing-sm) var(--spacing-md);
+    font-size: 13px;
+    min-width: unset;
+  }
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -27,10 +27,14 @@ function Header() {
 
   return (
     <div className="Header">
-      <Logo />
+      <div className="Header-left">
+        <Logo />
+      </div>
+      {!isAuthPage && userName && (
+        <div className="Hello">Hello, {userName}</div>
+      )}
       {!isAuthPage && (
-        <>
-          {userName && <div className="Hello">Hello, {userName}</div>}
+        <div className="Header-right">
           {isAuth ? (
             <div className="Header-actions">
               <Button
@@ -53,7 +57,7 @@ function Header() {
               onClick={() => navigate('/login')}
             />
           )}
-        </>
+        </div>
       )}
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,57 @@
+:root {
+  /* Components */
+  --button-width: 200px;
+  --button-width-sm: 160px;
+  
+  /* Colors — brand */
+  --color-primary: #007bff;
+  --color-primary-dark: #0056b3;
+  --color-danger: #dc3545;
+  --color-danger-dark: #b02a37;
+
+  /* Colors — text */
+  --color-text: #333;
+  --color-text-secondary: #555;
+  --color-text-muted: #666;
+
+  /* Colors — UI */
+  --color-background: #f5f5f5;
+  --color-surface: #ffffff;
+  --color-border: #ccc;
+  --color-border-light: #e0e0e0;
+  --color-error: #c0392b;
+
+  /* Shadows */
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.1);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.15);
+
+  /* Shape */
+  --border-radius: 4px;
+  --border-radius-lg: 8px;
+
+  /* Typography */
+  --font-size-sm: 12px;
+  --font-size-base: 14px;
+  --font-size-md: 16px;
+  --font-size-lg: 20px;
+
+  /* Spacing */
+  --spacing-xs: 4px;
+  --spacing-sm: 8px;
+  --spacing-md: 16px;
+  --spacing-lg: 20px;
+  --spacing-xl: 40px;
+}
+
 body {
   margin: 0;
   font-family:
-    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
-    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: var(--color-background);
 }
 
 code {


### PR DESCRIPTION
Define design tokens in :root (index.css):
- Colors: primary, danger, text variants, background, surface, border
- Shadows: sm, md
- Shape: border-radius, border-radius-lg
- Typography: font-size-sm/base/md/lg
- Spacing: xs/sm/md/lg/xl

Replace all hardcoded values with var() references:
- #007bff appears 0 times (was 8) — single source of truth
- #333, #666, #555 replaced with semantic color variables
- px spacing values replaced with spacing variables where appropriate

Additional fixes included:
- CourseInfo.css: remove .Button redefinition — was overriding global component
- CourseInfo.css: width: 1000px → max-width: 1000px (responsive fix)
- SearchBar.css: add border to input — was invisible without border
- SearchBar.css: remove dead .ButtonBar class
- Courses.css: remove dead .ButtonEnrolled class
- Header.css: replace fragile '> div:last-child' selector with .Header-right
- Header.tsx: add Header-left and Header-right wrapper divs