### PR TITLE
fix: replace selectIsEnrolled factory with parametric selector

### DIFF
--- a/src/components/CourseInfo/CourseInfo.tsx
+++ b/src/components/CourseInfo/CourseInfo.tsx
@@ -1,34 +1,19 @@
 import { useParams } from 'react-router-dom';
-
-import { useDispatch, useSelector } from 'react-redux';
-
-import {
-  selectAuthors,
-  selectAuthorsStatus,
-} from '../../store/authors/selectors';
-import {
-  selectCourses,
-  selectCoursesError,
-  selectCoursesStatus,
-} from '../../store/courses/selectors';
-import { fetchCourses } from '../../store/courses/thunk';
-import { selectIsEnrolled } from '../../store/enrollments/selectors';
-import { enrollCourse } from '../../store/enrollments/thunk';
-import { selectIsAdmin } from '../../store/user/selectors';
-
-import Button from '../../common/Button/Button';
-import ErrorMessage from '../../common/ErrorMessage/ErrorMessage';
+import { useSelector, useDispatch } from 'react-redux';
 
 import formatCreationDate from '../../helpers/formatCreationDate';
-import getAuthorNames from '../../helpers/getAuthorNames';
 import getCourseDuration from '../../helpers/getCourseDuration';
-
-import {
-  COURSE_INFO_LOADING_MESSAGE,
-  COURSE_INFO_NOT_FOUND_MESSAGE,
-} from '../../constants';
-
-import type { AppDispatch } from '../../store';
+import getAuthorNames from '../../helpers/getAuthorNames';
+import ErrorMessage from '../../common/ErrorMessage/ErrorMessage';
+import Button from '../../common/Button/Button';
+import { selectCourses, selectCoursesStatus, selectCoursesError } from '../../store/courses/selectors';
+import { selectAuthors, selectAuthorsStatus } from '../../store/authors/selectors';
+import { selectIsAdmin } from '../../store/user/selectors';
+import { selectIsEnrolled } from '../../store/enrollments/selectors';
+import { enrollCourse } from '../../store/enrollments/thunk';
+import { fetchCourses } from '../../store/courses/thunk';
+import { COURSE_INFO_LOADING_MESSAGE, COURSE_INFO_NOT_FOUND_MESSAGE } from '../../constants';
+import type { AppDispatch, RootState } from '../../store';
 import './CourseInfo.css';
 
 function CourseInfo() {
@@ -42,7 +27,9 @@ function CourseInfo() {
   const authors = useSelector(selectAuthors);
   const isAdmin = useSelector(selectIsAdmin);
 
-  const isEnrolled = useSelector(selectIsEnrolled(courseId ?? ''));
+  const isEnrolled = useSelector((state: RootState) =>
+    selectIsEnrolled(state, courseId ?? '')
+  );
 
   const isLoading = coursesStatus === 'loading' || authorsStatus === 'loading';
   const hasFailed = coursesStatus === 'failed';
@@ -97,22 +84,10 @@ function CourseInfo() {
             </p>
           </div>
           <div className="Course-det">
-            <p>
-              <strong>ID: </strong>
-              {course.id}
-            </p>
-            <p>
-              <strong>Duration: </strong>
-              {getCourseDuration(course.duration)}
-            </p>
-            <p>
-              <strong>Authors: </strong>
-              {authorNames}
-            </p>
-            <p>
-              <strong>Creation Date: </strong>
-              {formatCreationDate(course.creationDate)}
-            </p>
+            <p><strong>ID: </strong>{course.id}</p>
+            <p><strong>Duration: </strong>{getCourseDuration(course.duration)}</p>
+            <p><strong>Authors: </strong>{authorNames}</p>
+            <p><strong>Creation Date: </strong>{formatCreationDate(course.creationDate)}</p>
           </div>
         </div>
         {!isAdmin && (

--- a/src/components/Courses/components/CourseCard/CourseCard.tsx
+++ b/src/components/Courses/components/CourseCard/CourseCard.tsx
@@ -1,15 +1,14 @@
 import { useState } from 'react';
-
 import { useDispatch, useSelector } from 'react-redux';
 
 import Button from '../../../../common/Button/Button';
 import formatCreationDate from '../../../../helpers/formatCreationDate';
-import getAuthorNames from '../../../../helpers/getAuthorNames';
 import getCourseDuration from '../../../../helpers/getCourseDuration';
-import type { AppDispatch } from '../../../../store';
-import { selectIsEnrolled } from '../../../../store/enrollments/selectors';
+import getAuthorNames from '../../../../helpers/getAuthorNames';
 import { enrollCourse } from '../../../../store/enrollments/thunk';
-import type { Author, Course } from '../../../../types';
+import { selectIsEnrolled } from '../../../../store/enrollments/selectors';
+import type { Course, Author } from '../../../../types';
+import type { AppDispatch, RootState } from '../../../../store';
 import './CourseCard.css';
 
 interface CourseCardProps {
@@ -30,7 +29,9 @@ function CourseCard({
   onUpdate,
 }: CourseCardProps) {
   const dispatch = useDispatch<AppDispatch>();
-  const isEnrolled = useSelector(selectIsEnrolled(course.id));
+  const isEnrolled = useSelector((state: RootState) =>
+    selectIsEnrolled(state, course.id)
+  );
   const [enrollError, setEnrollError] = useState<string | null>(null);
 
   const handleEnroll = async (): Promise<void> => {
@@ -38,7 +39,9 @@ function CourseCard({
     const result = await dispatch(enrollCourse(course.id));
 
     if (enrollCourse.rejected.match(result)) {
-      setEnrollError(result.payload || 'Failed to enroll. Please try again.');
+      setEnrollError(
+        result.payload || 'Failed to enroll. Please try again.'
+      );
     }
   };
 
@@ -51,10 +54,7 @@ function CourseCard({
         </div>
         <div className="Course-details">
           <div className="Course-details-info">
-            <p>
-              Authors:{' '}
-              {getAuthorNames(course.authors, authors, { truncate: true })}
-            </p>
+            <p>Authors: {getAuthorNames(course.authors, authors, { truncate: true })}</p>
             <p>Duration: {getCourseDuration(course.duration)}</p>
             <p>Creation date: {formatCreationDate(course.creationDate)}</p>
           </div>
@@ -85,7 +85,9 @@ function CourseCard({
                 onClick={handleEnroll}
                 disabled={isEnrolled}
               />
-              {enrollError && <p className="enroll-error">{enrollError}</p>}
+              {enrollError && (
+                <p className="enroll-error">{enrollError}</p>
+              )}
             </>
           )}
         </div>

--- a/src/store/enrollments/selectors.ts
+++ b/src/store/enrollments/selectors.ts
@@ -2,14 +2,26 @@ import type { RootState } from '../index';
 
 export const selectEnrollments = (state: RootState) =>
   state.enrollments.enrollments;
+
 export const selectEnrollmentsStatus = (state: RootState) =>
   state.enrollments.status;
+
 export const selectEnrollmentsError = (state: RootState) =>
   state.enrollments.error;
 
-export const selectIsEnrolled =
-  (courseId: string) =>
-  (state: RootState): boolean =>
-    state.enrollments.enrollments.some(
-      (enrollment) => enrollment.courseId === courseId
-    );
+// Parametric selector — takes (state, courseId) instead of curried (courseId)(state).
+//
+// The curried factory pattern — selectIsEnrolled(courseId) called inside render —
+// returns a new function reference on every render. useSelector uses referential
+// equality to decide whether to re-run, so a new reference forces a re-run on
+// every store update, even unrelated ones. With a list of 50+ courses this is
+// a measurable performance issue.
+//
+// Usage: useSelector((state) => selectIsEnrolled(state, courseId))
+export const selectIsEnrolled = (
+  state: RootState,
+  courseId: string
+): boolean =>
+  state.enrollments.enrollments.some(
+    (enrollment) => enrollment.courseId === courseId
+  );


### PR DESCRIPTION
The curried factory pattern — selectIsEnrolled(courseId) called inside render — returned a new function reference on every render, causing useSelector to re-run on every store update regardless of relevance.

Rewritten as (state, courseId) => boolean and called via inline arrow:
  useSelector((state) => selectIsEnrolled(state, courseId))

useSelector now correctly skips re-renders when the boolean result hasn't changed. Fixes unnecessary re-renders on CourseCard and CourseInfo whenever any unrelated slice of the store updates.