### PR TITLE
fix: use UserRole type consistently instead of duplicated inline unions

### DIFF
--- a/src/store/user/selectors.ts
+++ b/src/store/user/selectors.ts
@@ -1,9 +1,9 @@
 import type { RootState } from '../index';
+import type { UserRole } from '../../types';
 
 export const selectUser = (state: RootState) => state.user;
 export const selectIsAuth = (state: RootState): boolean => state.user.isAuth;
-export const selectIsAdmin = (state: RootState): boolean =>
-  state.user.role === 'admin';
+export const selectIsAdmin = (state: RootState): boolean => state.user.role === 'admin';
 export const selectUserName = (state: RootState) => state.user.name;
-export const selectUserRole = (state: RootState) => state.user.role;
+export const selectUserRole = (state: RootState): UserRole | null => state.user.role;
 export const selectUserStatus = (state: RootState) => state.user.status;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,10 @@
 // ============================================================
+// Utility types — defined first so domain types can reference them
+// ============================================================
+
+export type UserRole = 'admin' | 'user';
+
+// ============================================================
 // Domain types — business entities
 // ============================================================
 
@@ -19,7 +25,7 @@ export interface Author {
 export interface User {
   name: string;
   email: string;
-  role: 'admin' | 'user';
+  role: UserRole;
 }
 
 export interface Enrollment {
@@ -66,7 +72,7 @@ export interface UserState {
   name: string | null;
   email: string | null;
   isAuth: boolean;
-  role: 'admin' | 'user' | null;
+  role: UserRole | null;
   status: LoadingStatus;
   error: string | null;
 }
@@ -110,9 +116,3 @@ export interface CourseFormFields {
   duration: string | number;
   newAuthorName: string;
 }
-
-// ============================================================
-// Utility types
-// ============================================================
-
-export type UserRole = 'admin' | 'user';


### PR DESCRIPTION
UserRole was declared in types/index.ts but User.role and UserState.role used inline 'admin' | 'user' unions — three separate definitions of the same domain concept.

- Moved UserRole to top of types/index.ts (before types that reference it)
- User.role and UserState.role now reference UserRole
- selectUserRole return type explicitly annotated as UserRole | null

Single source of truth — adding a new role now requires one change.