### PR TITLE
fix: handle disabled prop correctly when Button renders as Link

### DIFF
--- a/src/common/Button/Button.css
+++ b/src/common/Button/Button.css
@@ -57,14 +57,16 @@
   box-shadow: none;
 }
 
-.Button:disabled {
+.Button:disabled,
+.Button--disabled {
   background-color: var(--color-border);
   cursor: not-allowed;
   opacity: 0.6;
   box-shadow: none;
 }
 
-.Button:disabled:hover {
+.Button:disabled:hover,
+.Button--disabled:hover {
   background-color: var(--color-border);
   transform: none;
 }

--- a/src/common/Button/Button.tsx
+++ b/src/common/Button/Button.tsx
@@ -24,6 +24,21 @@ function Button({
   const classes = `Button Button--${variant} ${className}`.trim();
 
   if (to) {
+    if (disabled) {
+      if (import.meta.env.DEV) {
+        console.warn(
+          '[Button] Received both `to` and `disabled` props. ' +
+            'Rendering as a non-interactive <span>. ' +
+            'Consider whether this button should navigate at all when disabled.'
+        );
+      }
+      return (
+        <span className={`${classes} Button--disabled`} aria-disabled="true">
+          {label}
+        </span>
+      );
+    }
+
     return (
       <Link
         to={to}


### PR DESCRIPTION
<Link> has no native disabled state — passing disabled={true} alongside to= was silently ignored, leaving a fully clickable navigation button.

When both props are present, Button renders a <span> with aria-disabled=true and Button--disabled class instead of <Link>. CSS extended to apply disabled styles to .Button--disabled selector.