### PR TITLE
fix: disable Enroll button during pending request

### DIFF
--- a/src/components/CourseInfo/CourseInfo.tsx
+++ b/src/components/CourseInfo/CourseInfo.tsx
@@ -33,6 +33,7 @@ function CourseInfo() {
   );
 
   const [enrollError, setEnrollError] = useState<string | null>(null);
+  const [isEnrolling, setIsEnrolling] = useState<boolean>(false);
 
   const isLoading = coursesStatus === 'loading' || authorsStatus === 'loading';
   const hasFailed = coursesStatus === 'failed';
@@ -41,12 +42,13 @@ function CourseInfo() {
     dispatch(fetchCourses());
   };
 
-  // Previously: dispatch result was ignored — API errors silently dropped.
-  // Now matches the CourseCard pattern: check rejected action and surface the error.
   const handleEnroll = async (): Promise<void> => {
     if (!courseId) return;
     setEnrollError(null);
+    setIsEnrolling(true);
     const result = await dispatch(enrollCourse(courseId));
+    setIsEnrolling(false);
+
     if (enrollCourse.rejected.match(result)) {
       setEnrollError(
         result.payload || 'Failed to enroll. Please try again.'
@@ -105,10 +107,10 @@ function CourseInfo() {
         {!isAdmin && (
           <>
             <Button
-              label={isEnrolled ? 'Enrolled ✓' : 'Enroll in this course'}
+              label={isEnrolling ? 'Enrolling...' : isEnrolled ? 'Enrolled ✓' : 'Enroll in this course'}
               className={`enroll-button${isEnrolled ? ' enroll-button--enrolled' : ''}`}
               onClick={handleEnroll}
-              disabled={isEnrolled}
+              disabled={isEnrolled || isEnrolling}
             />
             {enrollError && (
               <p className="enroll-error">{enrollError}</p>

--- a/src/components/Courses/components/CourseCard/CourseCard.tsx
+++ b/src/components/Courses/components/CourseCard/CourseCard.tsx
@@ -33,10 +33,13 @@ function CourseCard({
     selectIsEnrolled(state, course.id)
   );
   const [enrollError, setEnrollError] = useState<string | null>(null);
+  const [isEnrolling, setIsEnrolling] = useState<boolean>(false);
 
   const handleEnroll = async (): Promise<void> => {
     setEnrollError(null);
+    setIsEnrolling(true);
     const result = await dispatch(enrollCourse(course.id));
+    setIsEnrolling(false);
 
     if (enrollCourse.rejected.match(result)) {
       setEnrollError(
@@ -80,10 +83,10 @@ function CourseCard({
           ) : (
             <>
               <Button
-                label={isEnrolled ? 'Enrolled ✓' : 'Enroll'}
+                label={isEnrolling ? 'Enrolling...' : isEnrolled ? 'Enrolled ✓' : 'Enroll'}
                 className={`Course-button${isEnrolled ? ' Course-button--enrolled' : ''}`}
                 onClick={handleEnroll}
-                disabled={isEnrolled}
+                disabled={isEnrolled || isEnrolling}
               />
               {enrollError && (
                 <p className="enroll-error">{enrollError}</p>


### PR DESCRIPTION
Button had no loading state — rapid clicks dispatched enrollCourse multiple times before the first request completed.

Added isEnrolling state in CourseCard and CourseInfo:
- button disabled while request is in flight (isEnrolled || isEnrolling)
- label changes to 'Enrolling...' for visual feedback
- setIsEnrolling(false) runs after dispatch resolves (fulfilled or rejected)