### PR TITLE
feat: add ErrorBoundary at application root

### DIFF
--- a/src/common/ErrorBoundary/ErrorBoundary.css
+++ b/src/common/ErrorBoundary/ErrorBoundary.css
@@ -1,0 +1,67 @@
+.ErrorBoundary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: var(--spacing-lg);
+  background-color: var(--color-background);
+}
+
+.ErrorBoundary-content {
+  max-width: 480px;
+  width: 100%;
+  text-align: center;
+  padding: var(--spacing-lg);
+  background: var(--color-surface);
+  border-radius: var(--border-radius);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.ErrorBoundary-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--color-danger);
+  margin-bottom: var(--spacing-sm);
+}
+
+.ErrorBoundary-message {
+  font-size: var(--font-size-base);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--spacing-lg);
+  line-height: 1.5;
+}
+
+.ErrorBoundary-detail {
+  text-align: left;
+  font-size: 0.8rem;
+  background: var(--color-background);
+  color: var(--color-danger);
+  padding: var(--spacing-sm);
+  border-radius: var(--border-radius);
+  margin-bottom: var(--spacing-lg);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.ErrorBoundary-button {
+  padding: 10px var(--spacing-lg);
+  font-size: var(--font-size-base);
+  font-weight: 500;
+  color: var(--color-surface);
+  background-color: var(--color-primary);
+  border: none;
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  font-family: inherit;
+}
+
+.ErrorBoundary-button:hover {
+  background-color: var(--color-primary-dark);
+}
+
+.ErrorBoundary-button:focus {
+  outline: 2px solid var(--color-primary-dark);
+  outline-offset: 2px;
+}

--- a/src/common/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/common/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,73 @@
+import { Component } from 'react';
+import type { ReactNode, ErrorInfo } from 'react';
+
+import './ErrorBoundary.css';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+// ErrorBoundary must be a class component — React's componentDidCatch
+// and getDerivedStateFromError lifecycle methods have no hook equivalents.
+//
+// Placed at the root (above <App>) so any unhandled runtime error in the
+// component tree shows a graceful fallback instead of a blank screen.
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // In production you'd send this to an error tracking service (Sentry etc.)
+    console.error('[ErrorBoundary] Uncaught error:', error, info.componentStack);
+  }
+
+  handleReset = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render(): ReactNode {
+    const { hasError, error } = this.state;
+    const { children, fallback } = this.props;
+
+    if (hasError) {
+      if (fallback) return fallback;
+
+      return (
+        <div className="ErrorBoundary" role="alert">
+          <div className="ErrorBoundary-content">
+            <h2 className="ErrorBoundary-title">Something went wrong</h2>
+            <p className="ErrorBoundary-message">
+              An unexpected error occurred. Please try refreshing the page.
+            </p>
+            {import.meta.env.DEV && error && (
+              <pre className="ErrorBoundary-detail">{error.message}</pre>
+            )}
+            <button
+              className="ErrorBoundary-button"
+              onClick={this.handleReset}
+              type="button"
+            >
+              Try again
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,11 @@
 import { StrictMode } from 'react';
-
 import { createRoot } from 'react-dom/client';
-
 import { BrowserRouter } from 'react-router-dom';
-
 import { Provider } from 'react-redux';
 
 import App from './App';
 import store from './store';
-
+import ErrorBoundary from './common/ErrorBoundary/ErrorBoundary';
 import './index.css';
 
 const rootElement = document.getElementById('root');
@@ -23,7 +20,9 @@ createRoot(rootElement).render(
   <StrictMode>
     <Provider store={store}>
       <BrowserRouter>
-        <App />
+        <ErrorBoundary>
+          <App />
+        </ErrorBoundary>
       </BrowserRouter>
     </Provider>
   </StrictMode>


### PR DESCRIPTION
Without an error boundary, any unhandled runtime error in the component tree unmounts the entire app and shows a blank screen in React 18+.

Added src/common/ErrorBoundary/ErrorBoundary.tsx:
- class component (required — no hook equivalent for componentDidCatch)
- getDerivedStateFromError: sets hasError state before re-render
- componentDidCatch: logs error + componentStack (Sentry-ready)
- handleReset: lets user recover without full page refresh
- error.message shown in dev mode only via import.meta.env.DEV
- accepts optional fallback prop for custom error UI per use case

Wrapped <App> in index.tsx inside <BrowserRouter> and <Provider> so the boundary has access to router and store context if needed.