### PR TITLE
test: extend courses and enrollments test coverage

### DIFF
--- a/src/components/Courses/components/SearchBar/SearchBar.test.tsx
+++ b/src/components/Courses/components/SearchBar/SearchBar.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+import SearchBar from './SearchBar';
+
+describe('SearchBar', () => {
+  it('renders a text input', () => {
+    render(<SearchBar value="" onSearch={vi.fn()} />);
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('displays the current value', () => {
+    render(<SearchBar value="react" onSearch={vi.fn()} />);
+    expect(screen.getByRole('textbox')).toHaveValue('react');
+  });
+
+  it('calls onSearch with input value when user types', async () => {
+    const onSearch = vi.fn();
+    render(<SearchBar value="" onSearch={onSearch} />);
+    await userEvent.type(screen.getByRole('textbox'), 'r');
+    expect(onSearch).toHaveBeenCalledWith('r');
+  });
+
+  it('prevents default form submission on submit', () => {
+    render(<SearchBar value="" onSearch={vi.fn()} />);
+    const form = screen.getByRole('textbox').closest('form')!;
+    const submitEvent = fireEvent.submit(form);
+    // fireEvent.submit returns false if preventDefault was called
+    expect(submitEvent).toBe(false);
+  });
+});

--- a/src/store/courses/reducer.test.ts
+++ b/src/store/courses/reducer.test.ts
@@ -1,7 +1,7 @@
 import type { Course, CoursesState } from '../../types';
 
 import coursesReducer from './reducer';
-import { createCourse, deleteCourse, fetchCourses } from './thunk';
+import { createCourse, deleteCourse, fetchCourses, updateCourse } from './thunk';
 
 const initialState: CoursesState = {
   courses: [],
@@ -18,50 +18,171 @@ const sampleCourse: Course = {
   creationDate: '2024-01-01T00:00:00Z',
 };
 
+const sampleCourse2: Course = {
+  id: '2',
+  title: 'Another Course',
+  description: 'Another Description',
+  duration: 90,
+  authors: [],
+  creationDate: '2024-02-01T00:00:00Z',
+};
+
 describe('Courses Reducer', () => {
   it('should return the initial state', () => {
     expect(coursesReducer(undefined, { type: '@@INIT' })).toEqual(initialState);
   });
 
-  it('should set status to loading on fetchCourses.pending', () => {
-    const action = { type: fetchCourses.pending.type };
-    const state = coursesReducer(initialState, action);
-    expect(state.status).toBe('loading');
-    expect(state.error).toBeNull();
+  describe('fetchCourses', () => {
+    it('should set status to loading on pending', () => {
+      const state = coursesReducer(initialState, {
+        type: fetchCourses.pending.type,
+      });
+      expect(state.status).toBe('loading');
+      expect(state.error).toBeNull();
+    });
+
+    it('should populate courses on fulfilled', () => {
+      const state = coursesReducer(initialState, {
+        type: fetchCourses.fulfilled.type,
+        payload: [sampleCourse],
+      });
+      expect(state.status).toBe('succeeded');
+      expect(state.courses).toEqual([sampleCourse]);
+    });
+
+    it('should set error on rejected', () => {
+      const state = coursesReducer(initialState, {
+        type: fetchCourses.rejected.type,
+        payload: 'Network error',
+      });
+      expect(state.status).toBe('failed');
+      expect(state.error).toBe('Network error');
+    });
+
+    it('should set error to null when rejected payload is undefined', () => {
+      const state = coursesReducer(initialState, {
+        type: fetchCourses.rejected.type,
+        payload: undefined,
+      });
+      expect(state.error).toBeNull();
+    });
   });
 
-  it('should populate courses on fetchCourses.fulfilled', () => {
-    const courses: Course[] = [sampleCourse];
-    const action = { type: fetchCourses.fulfilled.type, payload: courses };
-    const state = coursesReducer(initialState, action);
-    expect(state.status).toBe('succeeded');
-    expect(state.courses).toEqual(courses);
+  describe('createCourse', () => {
+    it('should add course on fulfilled', () => {
+      const state = coursesReducer(initialState, {
+        type: createCourse.fulfilled.type,
+        payload: sampleCourse,
+      });
+      expect(state.courses).toHaveLength(1);
+      expect(state.courses[0]).toEqual(sampleCourse);
+    });
+
+    it('should set status to failed and store error on rejected', () => {
+      const state = coursesReducer(initialState, {
+        type: createCourse.rejected.type,
+        payload: 'Create failed',
+      });
+      expect(state.status).toBe('failed');
+      expect(state.error).toBe('Create failed');
+    });
+
+    it('should set error to null when rejected payload is undefined', () => {
+      const state = coursesReducer(initialState, {
+        type: createCourse.rejected.type,
+        payload: undefined,
+      });
+      expect(state.error).toBeNull();
+    });
   });
 
-  it('should set error on fetchCourses.rejected', () => {
-    const action = {
-      type: fetchCourses.rejected.type,
-      payload: 'Network error',
-    };
-    const state = coursesReducer(initialState, action);
-    expect(state.status).toBe('failed');
-    expect(state.error).toBe('Network error');
+  describe('deleteCourse', () => {
+    it('should remove course on fulfilled', () => {
+      const stateWithCourse: CoursesState = {
+        ...initialState,
+        courses: [sampleCourse],
+      };
+      const state = coursesReducer(stateWithCourse, {
+        type: deleteCourse.fulfilled.type,
+        payload: '1',
+      });
+      expect(state.courses).toHaveLength(0);
+    });
+
+    it('should not remove other courses when deleting one', () => {
+      const stateWithCourses: CoursesState = {
+        ...initialState,
+        courses: [sampleCourse, sampleCourse2],
+      };
+      const state = coursesReducer(stateWithCourses, {
+        type: deleteCourse.fulfilled.type,
+        payload: '1',
+      });
+      expect(state.courses).toHaveLength(1);
+      expect(state.courses[0].id).toBe('2');
+    });
+
+    it('should set status to failed and store error on rejected', () => {
+      const state = coursesReducer(initialState, {
+        type: deleteCourse.rejected.type,
+        payload: 'Delete failed',
+      });
+      expect(state.status).toBe('failed');
+      expect(state.error).toBe('Delete failed');
+    });
+
+    it('should set error to null when rejected payload is undefined', () => {
+      const state = coursesReducer(initialState, {
+        type: deleteCourse.rejected.type,
+        payload: undefined,
+      });
+      expect(state.error).toBeNull();
+    });
   });
 
-  it('should add course on createCourse.fulfilled', () => {
-    const action = { type: createCourse.fulfilled.type, payload: sampleCourse };
-    const state = coursesReducer(initialState, action);
-    expect(state.courses).toHaveLength(1);
-    expect(state.courses[0]).toEqual(sampleCourse);
-  });
+  describe('updateCourse', () => {
+    it('should update existing course on fulfilled', () => {
+      const stateWithCourse: CoursesState = {
+        ...initialState,
+        courses: [sampleCourse],
+      };
+      const updatedCourse = { ...sampleCourse, title: 'Updated Title' };
+      const state = coursesReducer(stateWithCourse, {
+        type: updateCourse.fulfilled.type,
+        payload: updatedCourse,
+      });
+      expect(state.courses[0].title).toBe('Updated Title');
+    });
 
-  it('should remove course on deleteCourse.fulfilled', () => {
-    const stateWithCourse: CoursesState = {
-      ...initialState,
-      courses: [sampleCourse],
-    };
-    const action = { type: deleteCourse.fulfilled.type, payload: '1' };
-    const state = coursesReducer(stateWithCourse, action);
-    expect(state.courses).toHaveLength(0);
+    it('should not modify state when course id not found', () => {
+      const stateWithCourse: CoursesState = {
+        ...initialState,
+        courses: [sampleCourse],
+      };
+      const nonExistentCourse = { ...sampleCourse, id: 'nonexistent' };
+      const state = coursesReducer(stateWithCourse, {
+        type: updateCourse.fulfilled.type,
+        payload: nonExistentCourse,
+      });
+      // index === -1 branch — original course unchanged
+      expect(state.courses[0]).toEqual(sampleCourse);
+    });
+
+    it('should set status to failed and store error on rejected', () => {
+      const state = coursesReducer(initialState, {
+        type: updateCourse.rejected.type,
+        payload: 'Update failed',
+      });
+      expect(state.status).toBe('failed');
+      expect(state.error).toBe('Update failed');
+    });
+
+    it('should set error to null when rejected payload is undefined', () => {
+      const state = coursesReducer(initialState, {
+        type: updateCourse.rejected.type,
+        payload: undefined,
+      });
+      expect(state.error).toBeNull();
+    });
   });
 });

--- a/src/store/courses/thunk.test.ts
+++ b/src/store/courses/thunk.test.ts
@@ -12,18 +12,10 @@ import authorsReducer from '../authors/reducer';
 import enrollmentsReducer from '../enrollments/reducer';
 import userReducer from '../user/reducer';
 import coursesReducer from './reducer';
-import {
-  createCourse,
-  deleteCourse,
-  fetchCourses,
-  updateCourse,
-} from './thunk';
+import { createCourse, deleteCourse, fetchCourses, updateCourse } from './thunk';
 
 vi.mock('../../services');
 
-// vi.mocked() wraps the service function with Vitest mock types.
-// Without it TypeScript does not know that getCoursesService
-// has .mockResolvedValueOnce() method — it would show a type error.
 const mockedGetCourses = vi.mocked(getCoursesService);
 const mockedCreateCourse = vi.mocked(createCourseService);
 const mockedDeleteCourse = vi.mocked(deleteCourseService);
@@ -44,8 +36,6 @@ const initialCoursesState: CoursesState = {
   error: null,
 };
 
-// buildStore returns a fully typed store.
-// TypeScript infers its type from configureStore — no manual typing needed.
 const buildStore = (preloadedCourses: CoursesState = initialCoursesState) =>
   configureStore({
     reducer: {
@@ -65,10 +55,9 @@ describe('Courses Thunks', () => {
   });
 
   describe('fetchCourses', () => {
-    it('should dispatch fulfilled and populate courses on success', async () => {
-      const mockCourses: Course[] = [sampleCourse];
+    it('dispatches fulfilled and populates courses on success', async () => {
       mockedGetCourses.mockResolvedValueOnce({
-        data: { successful: true, result: mockCourses },
+        data: { successful: true, result: [sampleCourse] },
       } as any);
 
       const store = buildStore({ courses: [], status: 'idle', error: null });
@@ -76,21 +65,20 @@ describe('Courses Thunks', () => {
 
       const state = store.getState().courses;
       expect(state.status).toBe('succeeded');
-      expect(state.courses).toEqual(mockCourses);
+      expect(state.courses).toEqual([sampleCourse]);
     });
 
-    it('should dispatch rejected and set error on service failure', async () => {
+    it('dispatches rejected on service failure', async () => {
       mockedGetCourses.mockRejectedValueOnce(new Error('Network error'));
 
       const store = buildStore({ courses: [], status: 'idle', error: null });
       await store.dispatch(fetchCourses());
 
-      const state = store.getState().courses;
-      expect(state.status).toBe('failed');
-      expect(state.error).toBeDefined();
+      expect(store.getState().courses.status).toBe('failed');
+      expect(store.getState().courses.error).toBe('Network error');
     });
 
-    it('should dispatch rejected when successful flag is false', async () => {
+    it('dispatches rejected when successful flag is false', async () => {
       mockedGetCourses.mockResolvedValueOnce({
         data: { successful: false },
       } as any);
@@ -98,57 +86,60 @@ describe('Courses Thunks', () => {
       const store = buildStore({ courses: [], status: 'idle', error: null });
       await store.dispatch(fetchCourses());
 
-      const state = store.getState().courses;
-      expect(state.status).toBe('failed');
+      expect(store.getState().courses.status).toBe('failed');
+    });
+
+    it('uses fallback message when non-Error is thrown', async () => {
+      mockedGetCourses.mockRejectedValueOnce('string error');
+
+      const store = buildStore({ courses: [], status: 'idle', error: null });
+      await store.dispatch(fetchCourses());
+
+      expect(store.getState().courses.error).toBe('Failed to fetch courses.');
     });
   });
 
   describe('createCourse', () => {
-    it('should add course to state on success', async () => {
-      const newCourse: Course = {
-        ...sampleCourse,
-        id: '2',
-        title: 'New Course',
-      };
+    it('adds course to state on success', async () => {
+      const newCourse: Course = { ...sampleCourse, id: '2', title: 'New Course' };
       mockedCreateCourse.mockResolvedValueOnce({
         data: { successful: true, result: newCourse },
       } as any);
 
       const store = buildStore({ courses: [], status: 'idle', error: null });
       await store.dispatch(
-        createCourse({
-          title: 'New Course',
-          description: 'Description',
-          duration: 60,
-          authors: [],
-        })
+        createCourse({ title: 'New Course', description: 'Desc', duration: 60, authors: [] })
       );
 
-      const state = store.getState().courses;
-      expect(state.courses).toHaveLength(1);
-      expect(state.courses[0].title).toBe('New Course');
+      expect(store.getState().courses.courses).toHaveLength(1);
     });
 
-    it('should set error on failure', async () => {
+    it('dispatches rejected on failure', async () => {
       mockedCreateCourse.mockRejectedValueOnce(new Error('Create failed'));
 
       const store = buildStore({ courses: [], status: 'idle', error: null });
-      await store.dispatch(
-        createCourse({
-          title: 'New Course',
-          description: 'Description',
-          duration: 60,
-          authors: [],
-        })
+      const result = await store.dispatch(
+        createCourse({ title: 'New Course', description: 'Desc', duration: 60, authors: [] })
       );
 
-      const state = store.getState().courses;
-      expect(state.error).toBeDefined();
+      expect(createCourse.rejected.match(result)).toBe(true);
+      expect(store.getState().courses.error).toBe('Create failed');
+    });
+
+    it('uses fallback message when non-Error is thrown', async () => {
+      mockedCreateCourse.mockRejectedValueOnce('string error');
+
+      const store = buildStore({ courses: [], status: 'idle', error: null });
+      await store.dispatch(
+        createCourse({ title: 'New', description: 'Desc', duration: 60, authors: [] })
+      );
+
+      expect(store.getState().courses.error).toBe('Failed to create course.');
     });
   });
 
   describe('deleteCourse', () => {
-    it('should remove course from state on success', async () => {
+    it('removes course from state on success', async () => {
       mockedDeleteCourse.mockResolvedValueOnce({
         data: { successful: true },
       } as any);
@@ -156,14 +147,43 @@ describe('Courses Thunks', () => {
       const store = buildStore();
       await store.dispatch(deleteCourse('1'));
 
-      const state = store.getState().courses;
-      expect(state.courses).toHaveLength(0);
+      expect(store.getState().courses.courses).toHaveLength(0);
+    });
+
+    it('dispatches rejected when successful flag is false', async () => {
+      mockedDeleteCourse.mockResolvedValueOnce({
+        data: { successful: false },
+      } as any);
+
+      const store = buildStore();
+      const result = await store.dispatch(deleteCourse('1'));
+
+      expect(deleteCourse.rejected.match(result)).toBe(true);
+    });
+
+    it('dispatches rejected on service failure', async () => {
+      mockedDeleteCourse.mockRejectedValueOnce(new Error('Delete failed'));
+
+      const store = buildStore();
+      const result = await store.dispatch(deleteCourse('1'));
+
+      expect(deleteCourse.rejected.match(result)).toBe(true);
+      expect(store.getState().courses.error).toBe('Delete failed');
+    });
+
+    it('uses fallback message when non-Error is thrown', async () => {
+      mockedDeleteCourse.mockRejectedValueOnce('string error');
+
+      const store = buildStore();
+      await store.dispatch(deleteCourse('1'));
+
+      expect(store.getState().courses.error).toBe('Failed to delete course.');
     });
   });
 
   describe('updateCourse', () => {
-    it('should update course in state on success', async () => {
-      const updatedCourse: Course = { ...sampleCourse, title: 'Updated Title' };
+    it('updates course in state on success', async () => {
+      const updatedCourse = { ...sampleCourse, title: 'Updated Title' };
       mockedUpdateCourse.mockResolvedValueOnce({
         data: { successful: true, result: updatedCourse },
       } as any);
@@ -171,8 +191,37 @@ describe('Courses Thunks', () => {
       const store = buildStore();
       await store.dispatch(updateCourse(updatedCourse));
 
-      const state = store.getState().courses;
-      expect(state.courses[0].title).toBe('Updated Title');
+      expect(store.getState().courses.courses[0].title).toBe('Updated Title');
+    });
+
+    it('dispatches rejected when successful flag is false', async () => {
+      mockedUpdateCourse.mockResolvedValueOnce({
+        data: { successful: false },
+      } as any);
+
+      const store = buildStore();
+      const result = await store.dispatch(updateCourse(sampleCourse));
+
+      expect(updateCourse.rejected.match(result)).toBe(true);
+    });
+
+    it('dispatches rejected on service failure', async () => {
+      mockedUpdateCourse.mockRejectedValueOnce(new Error('Update failed'));
+
+      const store = buildStore();
+      const result = await store.dispatch(updateCourse(sampleCourse));
+
+      expect(updateCourse.rejected.match(result)).toBe(true);
+      expect(store.getState().courses.error).toBe('Update failed');
+    });
+
+    it('uses fallback message when non-Error is thrown', async () => {
+      mockedUpdateCourse.mockRejectedValueOnce('string error');
+
+      const store = buildStore();
+      await store.dispatch(updateCourse(sampleCourse));
+
+      expect(store.getState().courses.error).toBe('Failed to update course.');
     });
   });
 });

--- a/src/store/enrollments/selectors.test.ts
+++ b/src/store/enrollments/selectors.test.ts
@@ -1,0 +1,99 @@
+import { configureStore } from '@reduxjs/toolkit';
+
+import authorsReducer from '../authors/reducer';
+import coursesReducer from '../courses/reducer';
+import userReducer from '../user/reducer';
+import enrollmentsReducer from './reducer';
+import {
+  selectEnrollments,
+  selectEnrollmentsError,
+  selectEnrollmentsStatus,
+  selectIsEnrolled,
+} from './selectors';
+import type { Enrollment, EnrollmentsState } from '../../types';
+
+const sampleEnrollment: Enrollment = {
+  id: 'e1',
+  userEmail: 'user@test.com',
+  courseId: 'c1',
+  enrolledAt: '2024-01-01T00:00:00Z',
+};
+
+const buildStore = (enrollmentsState: EnrollmentsState) =>
+  configureStore({
+    reducer: {
+      enrollments: enrollmentsReducer,
+      courses: coursesReducer,
+      authors: authorsReducer,
+      user: userReducer,
+    },
+    preloadedState: {
+      enrollments: enrollmentsState,
+    },
+  });
+
+describe('Enrollments Selectors', () => {
+  describe('selectEnrollments', () => {
+    it('returns enrollments array', () => {
+      const store = buildStore({
+        enrollments: [sampleEnrollment],
+        status: 'succeeded',
+        error: null,
+      });
+      expect(selectEnrollments(store.getState())).toEqual([sampleEnrollment]);
+    });
+
+    it('returns empty array when no enrollments', () => {
+      const store = buildStore({ enrollments: [], status: 'idle', error: null });
+      expect(selectEnrollments(store.getState())).toEqual([]);
+    });
+  });
+
+  describe('selectEnrollmentsStatus', () => {
+    it('returns current status', () => {
+      const store = buildStore({ enrollments: [], status: 'loading', error: null });
+      expect(selectEnrollmentsStatus(store.getState())).toBe('loading');
+    });
+  });
+
+  describe('selectEnrollmentsError', () => {
+    it('returns error message when present', () => {
+      const store = buildStore({
+        enrollments: [],
+        status: 'failed',
+        error: 'Network error',
+      });
+      expect(selectEnrollmentsError(store.getState())).toBe('Network error');
+    });
+
+    it('returns null when no error', () => {
+      const store = buildStore({ enrollments: [], status: 'idle', error: null });
+      expect(selectEnrollmentsError(store.getState())).toBeNull();
+    });
+  });
+
+  describe('selectIsEnrolled', () => {
+    it('returns true when user is enrolled in course', () => {
+      const store = buildStore({
+        enrollments: [sampleEnrollment],
+        status: 'succeeded',
+        error: null,
+      });
+      expect(selectIsEnrolled(store.getState(), 'c1')).toBe(true);
+    });
+
+    it('returns false when user is not enrolled in course', () => {
+      const store = buildStore({
+        enrollments: [sampleEnrollment],
+        status: 'succeeded',
+        error: null,
+      });
+      expect(selectIsEnrolled(store.getState(), 'c2')).toBe(false);
+    });
+
+    it('returns false when enrollments is empty', () => {
+      const store = buildStore({ enrollments: [], status: 'idle', error: null });
+      expect(selectIsEnrolled(store.getState(), 'c1')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
- courses/reducer.test.ts: add createCourse.rejected, deleteCourse.rejected, updateCourse (index !== -1 branch), all ?? null branches
- courses/thunk.test.ts: add deleteCourse/updateCourse rejected paths, successful: false cases, non-Error fallback messages
- SearchBar.test.tsx: cover handleChange and handleSubmit
- enrollments/selectors.test.ts: cover all 4 selectors including selectIsEnrolled