### PR TITLE
fix: add Input.css and import it in Input.tsx

### DIFF
--- a/src/common/Input/Input.css
+++ b/src/common/Input/Input.css
@@ -1,0 +1,32 @@
+.input-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.input-wrapper input {
+  width: 100%;
+  padding: 8px 12px;
+  font-size: var(--font-size-base, 14px);
+  font-family: inherit;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: var(--border-radius, 4px);
+  background-color: var(--color-surface, #fff);
+  color: var(--color-text-primary);
+  transition: border-color 0.2s ease;
+}
+
+.input-wrapper input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.input-wrapper input.has-error {
+  border-color: var(--color-danger);
+}
+
+.error-text {
+  font-size: 12px;
+  color: var(--color-danger);
+}

--- a/src/common/Input/Input.tsx
+++ b/src/common/Input/Input.tsx
@@ -1,5 +1,7 @@
 import type { ChangeEvent } from 'react';
 
+import './Input.css';
+
 interface InputProps {
   name: string;
   value: string | number;
@@ -25,6 +27,7 @@ function Input({
         value={value}
         onChange={onChange}
         placeholder={placeholder}
+        className={error ? 'has-error' : undefined}
       />
       {error && <small className="error-text">{error}</small>}
     </div>


### PR DESCRIPTION
Input component used class names (input-wrapper, error-text, has-error) but had no own CSS file — styles were implicitly relying on globals. Added Input.css with explicit styles and has-error class on the input element when error prop is present.