### PR TITLE
fix: update qs to 6.15.2 to address CVE-2026-8723 [SECURITY]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6008,9 +6008,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,


### PR DESCRIPTION
Indirect dependency via axios. qs 6.11.1-6.15.1 vulnerable to remotely triggerable DoS in qs.stringify with arrayFormat:'comma' and encodeValuesOnly:true on null/undefined array entries. CVSS: 6.3 (Medium) - GHSA-q8mj-m7cp-5q26