### PR TITLE
fix: set user slice initialState status to idle instead of bootstrapping

### DIFF
--- a/src/store/user/reducer.test.ts
+++ b/src/store/user/reducer.test.ts
@@ -8,7 +8,7 @@ const initialState: UserState = {
   email: null,
   isAuth: false,
   role: null,
-  status: 'bootstrapping',
+  status: 'idle',
   error: null,
 };
 

--- a/src/store/user/reducer.ts
+++ b/src/store/user/reducer.ts
@@ -10,7 +10,7 @@ const initialState: UserState = {
   email: null,
   isAuth: false,
   role: null,
-  status: 'bootstrapping',
+  status: 'idle',
   error: null,
 };
 


### PR DESCRIPTION
bootstrapping is the in-flight status for fetchUser — it should only be set in fetchUser.pending, not in the initial state. Previously, any store created without dispatching fetchUser (e.g. in tests without preloadedState) had isBootstrapping=true by default, which would show a loading spinner indefinitely.