### PR TITLE
fix: add npm engine constraint and document axios interceptor redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=20",
+    "npm": ">=7"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.12.0",

--- a/src/services.ts
+++ b/src/services.ts
@@ -27,6 +27,9 @@ apiClient.interceptors.response.use(
     // A 401 on /users/me simply means the user is not authenticated —
     // it is the expected response during app bootstrapping.
     if (status === 401 && !url.includes('/users/me')) {
+      // navigate() is not available outside the React component tree.
+      // Hard redirect is intentional — clears all in-flight requests
+      // and resets the browser to /login cleanly.
       window.location.href = '/login';
     }
 


### PR DESCRIPTION
- package.json: add npm >=7 to engines (required for type:module + workspaces)
- services.ts: document why window.location.href is used instead of navigate() in the Axios interceptor (outside React component tree)